### PR TITLE
Update to latest HashMap API

### DIFF
--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -195,8 +195,7 @@ pub const Registry = struct {
     }
 
     pub fn deinit(self: *Registry) void {
-        var it = self.components.iterator();
-        while (it.next()) |ptr| {
+        for (self.components.items()) |ptr| {
             // HACK: we dont know the Type here but we need to call deinit
             var storage = @intToPtr(*Storage(u1), ptr.value);
             storage.deinit();
@@ -343,8 +342,7 @@ pub const Registry = struct {
     pub fn removeAll(self: *Registry, entity: Entity) void {
         assert(self.valid(entity));
 
-        var it = self.components.iterator();
-        while (it.next()) |ptr| {
+        for (self.components.items()) |ptr| {
             // HACK: we dont know the Type here but we need to be able to call methods on the Storage(T)
             var store = @intToPtr(*Storage(u1), ptr.value);
             store.removeIfContains(entity);

--- a/src/ecs/type_store.zig
+++ b/src/ecs/type_store.zig
@@ -14,8 +14,7 @@ pub const TypeStore = struct {
     }
 
     pub fn deinit(self: *TypeStore) void {
-        var iter = self.map.iterator();
-        while (iter.next()) |kv| {
+        for (self.map.items()) |kv| {
             self.allocator.free(kv.value);
         }
         self.map.deinit();

--- a/src/resources/assets.zig
+++ b/src/resources/assets.zig
@@ -14,8 +14,7 @@ pub const Assets = struct {
     }
 
     pub fn deinit(self: *Assets) void {
-        var it = self.caches.iterator();
-        while (it.next()) |ptr| {
+        for (self.caches.items()) |ptr| {
             // HACK: we dont know the Type here but we need to call deinit
             @intToPtr(*Cache(u1), ptr.value).deinit();
         }

--- a/src/resources/cache.zig
+++ b/src/resources/cache.zig
@@ -67,8 +67,7 @@ pub fn Cache(comptime T: type) type {
         pub fn clear(self: *@This()) void {
             // optionally deinit any resources that have a deinit method
             if (@hasDecl(T, "deinit")) {
-                var iter = self.resources.iterator();
-                while (iter.next()) |kv| {
+                for (self.resources.items()) |kv| {
                     @call(.{ .modifier = .always_inline }, @field(kv.value, "deinit"), .{});
                 }
             }

--- a/src/signals/dispatcher.zig
+++ b/src/signals/dispatcher.zig
@@ -15,8 +15,7 @@ pub const Dispatcher = struct {
     }
 
     pub fn deinit(self: *Dispatcher) void {
-        var it = self.signals.iterator();
-        while (it.next()) |ptr| {
+        for (self.signals.items()) |ptr| {
             // HACK: we dont know the Type here but we need to call deinit
             var signal = @intToPtr(*Signal(void), ptr.value);
             signal.deinit();


### PR DESCRIPTION
`.iterator()` is deprecated, iterating over the items directly is now supported