### PR TITLE
Fix for Handles and EntityTraits unsigned assertion with the new std.builtin.Signedness

### DIFF
--- a/src/ecs/entity.zig
+++ b/src/ecs/entity.zig
@@ -14,9 +14,9 @@ pub fn EntityTraitsType(comptime size: EntityTraitsSize) type {
 }
 
 fn EntityTraitsDefinition(comptime EntityType: type, comptime IndexType: type, comptime VersionType: type) type {
-    std.debug.assert(@typeInfo(EntityType) == .Int and !@typeInfo(EntityType).Int.is_signed);
-    std.debug.assert(@typeInfo(IndexType) == .Int and !@typeInfo(IndexType).Int.is_signed);
-    std.debug.assert(@typeInfo(VersionType) == .Int and !@typeInfo(VersionType).Int.is_signed);
+    std.debug.assert(@typeInfo(EntityType) == .Int and typeInfo(EntityType).Int.signedness == .unsigned);
+    std.debug.assert(@typeInfo(IndexType) == .Int and typeInfo(IndexType).Int.signedness == .unsigned);
+    std.debug.assert(@typeInfo(VersionType) == .Int and typeInfo(VersionType).Int.signedness == .unsigned);
 
     if (@bitSizeOf(IndexType) + @bitSizeOf(VersionType) != @bitSizeOf(EntityType))
         @compileError("IndexType and VersionType must sum to EntityType's bit count");

--- a/src/ecs/handles.zig
+++ b/src/ecs/handles.zig
@@ -4,9 +4,9 @@ const std = @import("std");
 /// you choose the type of the handle (aka its size) and how much of that goes to the index and the version.
 /// the bitsize of version + id must equal the handle size.
 pub fn Handles(comptime HandleType: type, comptime IndexType: type, comptime VersionType: type) type {
-    std.debug.assert(@typeInfo(HandleType) == .Int and !@typeInfo(HandleType).Int.is_signed);
-    std.debug.assert(@typeInfo(IndexType) == .Int and !@typeInfo(IndexType).Int.is_signed);
-    std.debug.assert(@typeInfo(VersionType) == .Int and !@typeInfo(VersionType).Int.is_signed);
+    std.debug.assert(@typeInfo(HandleType) == .Int and @typeInfo(HandleType).Int.signedness == .unsigned);
+    std.debug.assert(@typeInfo(IndexType) == .Int and @typeInfo(IndexType).Int.signedness == .unsigned);
+    std.debug.assert(@typeInfo(VersionType) == .Int and @typeInfo(VersionType).signedness == .unsigned);
 
     if (@bitSizeOf(IndexType) + @bitSizeOf(VersionType) != @bitSizeOf(HandleType))
         @compileError("IndexType and VersionType must sum to HandleType's bit count");


### PR DESCRIPTION
Hi, wasn't able to compile with zig version `0.7.0+500fbdad5` due to a recent zig PR [#6713](https://github.com/ziglang/zig/pull/6713) that changes `std.builtin.Int` to have a new `signedness` field.

I don't think this occured with version `0.7.0`.
Not sure if you want to support zig master or keep it synced to minor versions, so feel free to reject the PR.