### PR TITLE
Update to zig 0.8.0-dev.1721

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -25,12 +25,12 @@ pub fn build(b: *Builder) void {
         exe.linkSystemLibrary("c");
 
         const run_cmd = exe.run();
-        const exe_step = b.step(name, b.fmt("run {}.zig", .{name}));
+        const exe_step = b.step(name, b.fmt("run {s}.zig", .{name}));
         exe_step.dependOn(&run_cmd.step);
 
         // first element in the list is added as "run" so "zig build run" works
         if (i == 0) {
-            const run_exe_step = b.step("run", b.fmt("run {}.zig", .{name}));
+            const run_exe_step = b.step("run", b.fmt("run {s}.zig", .{name}));
             run_exe_step.dependOn(&run_cmd.step);
         }
     }

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -593,7 +593,7 @@ pub const Registry = struct {
 
     /// given the 3 group Types arrays, generates a (mostly) unique u64 hash. Simultaneously ensures there are no duped types between
     /// the 3 groups.
-    inline fn hashGroupTypes(comptime owned: anytype, comptime includes: anytype, comptime excludes: anytype) u64 {
+    fn hashGroupTypes(comptime owned: anytype, comptime includes: anytype, comptime excludes: anytype) callconv(.Inline) u64 {
         comptime {
             for (owned) |t1| {
                 for (includes) |t2| {
@@ -615,7 +615,7 @@ pub const Registry = struct {
     }
 
     /// expects a tuple of types. Convertes them to type names, sorts them then concatenates and returns the string.
-    inline fn concatTypes(comptime types: anytype) []const u8 {
+    fn concatTypes(comptime types: anytype) callconv(.Inline) []const u8 {
         comptime {
             if (types.len == 0) return "_";
 


### PR DESCRIPTION
Changes string formatting to use `{s}` and `inline fn` to `inline fn() callconv(.Inline)`.