### PR TITLE
Update to Zig 0.8.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -63,7 +63,7 @@ pub fn getPackage(comptime prefix_path: []const u8) std.build.Pkg {
 }
 
 /// prefix_path is used to add package paths. It should be the the same path used to include this build file
-pub fn linkArtifact(b: *Builder, artifact: *std.build.LibExeObjStep, target: std.build.Target, lib_type: LibType, comptime prefix_path: []const u8) void {
+pub fn linkArtifact(b: *Builder, artifact: *std.build.LibExeObjStep, _: std.build.Target, lib_type: LibType, comptime prefix_path: []const u8) void {
     const build_mode = b.standardReleaseOptions();
     switch (lib_type) {
         .static => {

--- a/src/ecs/actor.zig
+++ b/src/ecs/actor.zig
@@ -53,11 +53,11 @@ test "actor" {
     std.debug.assert(!actor.has(f32));
     actor.addTyped(f32, 67.45);
     if (actor.tryGet(f32)) |val| {
-        std.testing.expectEqual(val.*, 67.45);
+        try std.testing.expectEqual(val.*, 67.45);
     }
 
     actor.addTyped(u64, 8888);
-    std.testing.expectEqual(actor.get(u64).*, 8888);
+    try std.testing.expectEqual(actor.get(u64).*, 8888);
     std.debug.assert(actor.has(u64));
 
     actor.remove(u64);
@@ -83,6 +83,6 @@ test "actor structs" {
     pos.*.x += vel.x;
     pos.*.y += vel.y;
 
-    std.testing.expectEqual(actor.get(Position).*.x, 5);
-    std.testing.expectEqual(actor.get(Position).*.y, 10);
+    try std.testing.expectEqual(actor.get(Position).*.x, 5);
+    try std.testing.expectEqual(actor.get(Position).*.y, 10);
 }

--- a/src/ecs/component_storage.zig
+++ b/src/ecs/component_storage.zig
@@ -294,15 +294,15 @@ test "add/try-get/remove/clear" {
     defer store.deinit();
 
     store.add(3, 66.45);
-    std.testing.expectEqual(store.tryGetConst(3).?, 66.45);
+    try std.testing.expectEqual(store.tryGetConst(3).?, 66.45);
     if (store.tryGet(3)) |found| {
-        std.testing.expectEqual(@as(f32, 66.45), found.*);
+        try std.testing.expectEqual(@as(f32, 66.45), found.*);
     }
 
     store.remove(3);
 
     var val_null = store.tryGet(3);
-    std.testing.expectEqual(val_null, null);
+    try std.testing.expectEqual(val_null, null);
 
     store.clear();
 }
@@ -312,11 +312,11 @@ test "add/get/remove" {
     defer store.deinit();
 
     store.add(3, 66.45);
-    if (store.tryGet(3)) |found| std.testing.expectEqual(@as(f32, 66.45), found.*);
-    std.testing.expectEqual(store.tryGetConst(3).?, 66.45);
+    if (store.tryGet(3)) |found| try std.testing.expectEqual(@as(f32, 66.45), found.*);
+    try std.testing.expectEqual(store.tryGetConst(3).?, 66.45);
 
     store.remove(3);
-    std.testing.expectEqual(store.tryGet(3), null);
+    try std.testing.expectEqual(store.tryGet(3), null);
 }
 
 test "iterate" {
@@ -329,13 +329,13 @@ test "iterate" {
 
     for (store.data()) |entity, i| {
         if (i == 0) {
-            std.testing.expectEqual(entity, 3);
+            try std.testing.expectEqual(entity, 3);
         }
         if (i == 1) {
-            std.testing.expectEqual(entity, 5);
+            try std.testing.expectEqual(entity, 5);
         }
         if (i == 2) {
-            std.testing.expectEqual(entity, 7);
+            try std.testing.expectEqual(entity, 7);
         }
     }
 }
@@ -394,14 +394,14 @@ test "sort empty component" {
     comptime const asc_u32 = std.sort.asc(u32);
     store.sort(u32, {}, asc_u32);
     for (store.data()) |e, i| {
-        std.testing.expectEqual(@intCast(u32, i), e);
+        try std.testing.expectEqual(@intCast(u32, i), e);
     }
 
     comptime const desc_u32 = std.sort.desc(u32);
     store.sort(u32, {}, desc_u32);
     var counter: u32 = 2;
     for (store.data()) |e, i| {
-        std.testing.expectEqual(counter, e);
+        try std.testing.expectEqual(counter, e);
         if (counter > 0) counter -= 1;
     }
 }
@@ -428,7 +428,7 @@ test "sort by entity" {
 
     var compare: f32 = 5;
     for (store.raw()) |val, i| {
-        std.testing.expect(compare > val);
+        try std.testing.expect(compare > val);
         compare = val;
     }
 }
@@ -446,7 +446,7 @@ test "sort by component" {
 
     var compare: f32 = 5;
     for (store.raw()) |val, i| {
-        std.testing.expect(compare > val);
+        try std.testing.expect(compare > val);
         compare = val;
     }
 }

--- a/src/ecs/component_storage.zig
+++ b/src/ecs/component_storage.zig
@@ -11,7 +11,7 @@ pub fn ComponentStorage(comptime Component: type, comptime Entity: type) type {
     std.debug.assert(!utils.isComptime(Component));
 
     // empty (zero-sized) structs will not have an array created
-    comptime const is_empty_struct = @sizeOf(Component) == 0;
+    const is_empty_struct = @sizeOf(Component) == 0;
 
     // HACK: due to this being stored as untyped ptrs, when deinit is called we are casted to a Component of some random
     // non-zero sized type. That will make is_empty_struct false in deinit always so we can't use it. Instead, we stick
@@ -391,16 +391,16 @@ test "sort empty component" {
     store.add(2, Empty{});
     store.add(0, Empty{});
 
-    comptime const asc_u32 = std.sort.asc(u32);
+    const asc_u32 = comptime std.sort.asc(u32);
     store.sort(u32, {}, asc_u32);
     for (store.data()) |e, i| {
         try std.testing.expectEqual(@intCast(u32, i), e);
     }
 
-    comptime const desc_u32 = std.sort.desc(u32);
+    const desc_u32 = comptime std.sort.desc(u32);
     store.sort(u32, {}, desc_u32);
     var counter: u32 = 2;
-    for (store.data()) |e, i| {
+    for (store.data()) |e| {
         try std.testing.expectEqual(counter, e);
         if (counter > 0) counter -= 1;
     }
@@ -427,7 +427,7 @@ test "sort by entity" {
     store.sort(u32, store.len(), context, SortContext.sort);
 
     var compare: f32 = 5;
-    for (store.raw()) |val, i| {
+    for (store.raw()) |val| {
         try std.testing.expect(compare > val);
         compare = val;
     }
@@ -441,11 +441,11 @@ test "sort by component" {
     store.add(11, @as(f32, 1.1));
     store.add(33, @as(f32, 3.3));
 
-    comptime const desc_f32 = std.sort.desc(f32);
+    const desc_f32 = comptime std.sort.desc(f32);
     store.sort(f32, store.len(), {}, desc_f32);
 
     var compare: f32 = 5;
-    for (store.raw()) |val, i| {
+    for (store.raw()) |val| {
         try std.testing.expect(compare > val);
         compare = val;
     }

--- a/src/ecs/entity.zig
+++ b/src/ecs/entity.zig
@@ -41,7 +41,7 @@ test "entity traits" {
     const m = EntityTraitsType(.medium).init();
     const l = EntityTraitsType(.large).init();
 
-    std.testing.expectEqual(sm.entity_mask, std.math.maxInt(sm.index_type));
-    std.testing.expectEqual(m.entity_mask, std.math.maxInt(m.index_type));
-    std.testing.expectEqual(l.entity_mask, std.math.maxInt(l.index_type));
+    try std.testing.expectEqual(sm.entity_mask, std.math.maxInt(sm.index_type));
+    try std.testing.expectEqual(m.entity_mask, std.math.maxInt(m.index_type));
+    try std.testing.expectEqual(l.entity_mask, std.math.maxInt(l.index_type));
 }

--- a/src/ecs/groups.zig
+++ b/src/ecs/groups.zig
@@ -287,13 +287,13 @@ test "BasicGroup creation/iteration" {
 
     var iterated_entities: usize = 0;
     var iter = group.iterator();
-    while (iter.next()) |entity| {
+    while (iter.next()) |_| {
         iterated_entities += 1;
     }
     try std.testing.expectEqual(iterated_entities, 1);
 
     iterated_entities = 0;
-    for (group.data()) |entity| {
+    for (group.data()) |_| {
         iterated_entities += 1;
     }
     try std.testing.expectEqual(iterated_entities, 1);
@@ -316,7 +316,7 @@ test "BasicGroup excludes" {
 
     var iterated_entities: usize = 0;
     var iter = group.iterator();
-    while (iter.next()) |entity| {
+    while (iter.next()) |_| {
         iterated_entities += 1;
     }
     try std.testing.expectEqual(iterated_entities, 1);
@@ -422,7 +422,7 @@ test "OwningGroup each" {
     reg.add(e0, @as(u32, 55));
 
     const Thing = struct {
-        fn each(self: @This(), components: struct {
+        fn each(_: @This(), components: struct {
             int: *i32,
             uint: *u32,
         }) void {
@@ -449,9 +449,9 @@ test "multiple OwningGroups" {
     // var group1 = reg.group(.{u64, u32}, .{}, .{});
     // var group2 = reg.group(.{u64, u32, u8}, .{}, .{});
 
-    var group5 = reg.group(.{ Sprite, Transform }, .{ Renderable, Rotation }, .{});
-    var group3 = reg.group(.{Sprite}, .{Renderable}, .{});
-    var group4 = reg.group(.{ Sprite, Transform }, .{Renderable}, .{});
+    _ = reg.group(.{ Sprite, Transform }, .{ Renderable, Rotation }, .{});
+    _ = reg.group(.{Sprite}, .{Renderable}, .{});
+    _ = reg.group(.{ Sprite, Transform }, .{Renderable}, .{});
 
     // ensure groups are ordered correctly internally
     var last_size: u8 = 0;

--- a/src/ecs/handles.zig
+++ b/src/ecs/handles.zig
@@ -136,7 +136,7 @@ test "handles" {
     hm.remove(e1) catch unreachable;
     std.debug.assert(!hm.alive(e1));
 
-    std.testing.expectError(error.RemovedInvalidHandle, hm.remove(e1));
+    try std.testing.expectError(error.RemovedInvalidHandle, hm.remove(e1));
 
     var e_tmp = hm.create();
     std.debug.assert(hm.alive(e_tmp));

--- a/src/ecs/handles.zig
+++ b/src/ecs/handles.zig
@@ -58,11 +58,11 @@ pub fn Handles(comptime HandleType: type, comptime IndexType: type, comptime Ver
             self.allocator.free(self.handles);
         }
 
-        pub fn extractId(self: Self, handle: HandleType) IndexType {
+        pub fn extractId(_: Self, handle: HandleType) IndexType {
             return @truncate(IndexType, handle);
         }
 
-        pub fn extractVersion(self: Self, handle: HandleType) VersionType {
+        pub fn extractVersion(_: Self, handle: HandleType) VersionType {
             return @truncate(VersionType, handle >> @bitSizeOf(IndexType));
         }
 

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -255,12 +255,12 @@ pub const Registry = struct {
     }
 
     /// Returns the entity identifier without the version
-    pub fn entityId(self: Registry, entity: Entity) Entity {
+    pub fn entityId(_: Registry, entity: Entity) Entity {
         return entity & entity_traits.entity_mask;
     }
 
     /// Returns the version stored along with an entity identifier
-    pub fn version(self: *Registry, entity: Entity) entity_traits.version_type {
+    pub fn version(_: *Registry, entity: Entity) entity_traits.version_type {
         return @truncate(entity_traits.version_type, entity >> @bitSizeOf(entity_traits.index_type));
     }
 
@@ -471,7 +471,7 @@ pub const Registry = struct {
         std.debug.assert(owned.len + includes.len + excludes.len > 1);
 
         // create a unique hash to identify the group so that we can look it up
-        comptime const hash = comptime hashGroupTypes(owned, includes, excludes);
+        const hash = comptime hashGroupTypes(owned, includes, excludes);
 
         for (self.groups.items) |grp| {
             if (grp.hash == hash) {
@@ -606,9 +606,9 @@ pub const Registry = struct {
                 }
             }
 
-            const owned_str = comptime concatTypes(owned);
-            const includes_str = comptime concatTypes(includes);
-            const excludes_str = comptime concatTypes(excludes);
+            const owned_str = concatTypes(owned);
+            const includes_str = concatTypes(includes);
+            const excludes_str = concatTypes(excludes);
 
             return utils.hashStringFnv(u64, owned_str ++ includes_str ++ excludes_str);
         }
@@ -620,7 +620,7 @@ pub const Registry = struct {
             if (types.len == 0) return "_";
 
             const impl = struct {
-                fn asc(context: void, lhs: []const u8, rhs: []const u8) bool {
+                fn asc(_: void, lhs: []const u8, rhs: []const u8) bool {
                     return std.mem.lessThan(u8, lhs, rhs);
                 }
             };

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -195,10 +195,10 @@ pub const Registry = struct {
     }
 
     pub fn deinit(self: *Registry) void {
-        var iter = self.components.iterator();
+        var iter = self.components.valueIterator();
         while (iter.next()) |ptr| {
             // HACK: we dont know the Type here but we need to call deinit
-            var storage = @intToPtr(*Storage(u1), ptr.value);
+            var storage = @intToPtr(*Storage(u1), ptr.*);
             storage.deinit();
         }
 
@@ -216,7 +216,7 @@ pub const Registry = struct {
     pub fn assure(self: *Registry, comptime T: type) *Storage(T) {
         var type_id = utils.typeId(T);
         if (self.components.getEntry(type_id)) |kv| {
-            return @intToPtr(*Storage(T), kv.value);
+            return @intToPtr(*Storage(T), kv.value_ptr.*);
         }
 
         var comp_set = Storage(T).initPtr(self.allocator);
@@ -593,7 +593,7 @@ pub const Registry = struct {
 
     /// given the 3 group Types arrays, generates a (mostly) unique u64 hash. Simultaneously ensures there are no duped types between
     /// the 3 groups.
-    fn hashGroupTypes(comptime owned: anytype, comptime includes: anytype, comptime excludes: anytype) callconv(.Inline) u64 {
+    inline fn hashGroupTypes(comptime owned: anytype, comptime includes: anytype, comptime excludes: anytype) u64 {
         comptime {
             for (owned) |t1| {
                 for (includes) |t2| {
@@ -615,7 +615,7 @@ pub const Registry = struct {
     }
 
     /// expects a tuple of types. Convertes them to type names, sorts them then concatenates and returns the string.
-    fn concatTypes(comptime types: anytype) callconv(.Inline) []const u8 {
+    inline fn concatTypes(comptime types: anytype) []const u8 {
         comptime {
             if (types.len == 0) return "_";
 

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -343,10 +343,10 @@ pub const Registry = struct {
     pub fn removeAll(self: *Registry, entity: Entity) void {
         assert(self.valid(entity));
 
-        var iter = self.components.iterator();
-        while (iter.next()) |ptr| {
+        var iter = self.components.valueIterator();
+        while (iter.next()) |value| {
             // HACK: we dont know the Type here but we need to be able to call methods on the Storage(T)
-            var store = @intToPtr(*Storage(u1), ptr.value);
+            var store = @intToPtr(*Storage(u1), value.*);
             store.removeIfContains(entity);
         }
     }

--- a/src/ecs/sparse_set.zig
+++ b/src/ecs/sparse_set.zig
@@ -35,7 +35,7 @@ pub fn SparseSet(comptime SparseT: type) type {
 
         pub fn deinit(self: *Self) void {
             self.sparse.expandToCapacity();
-            for (self.sparse.items) |array, i| {
+            for (self.sparse.items) |array| {
                 if (array) |arr| {
                     self.sparse.allocator.free(arr);
                 }
@@ -53,7 +53,7 @@ pub fn SparseSet(comptime SparseT: type) type {
             return (sparse & self.entity_mask) / entity_per_page;
         }
 
-        fn offset(self: Self, sparse: SparseT) usize {
+        fn offset(_: Self, sparse: SparseT) usize {
             return sparse & (entity_per_page - 1);
         }
 
@@ -151,7 +151,7 @@ pub fn SparseSet(comptime SparseT: type) type {
         pub fn sort(self: *Self, context: anytype, comptime lessThan: fn (@TypeOf(context), SparseT, SparseT) bool) void {
             std.sort.insertionSort(SparseT, self.dense.items, context, lessThan);
 
-            for (self.dense.items) |sparse, i| {
+            for (self.dense.items) |_, i| {
                 const item = @intCast(SparseT, i);
                 self.sparse.items[self.page(self.dense.items[self.page(item)])].?[self.offset(self.dense.items[self.page(item)])] = @intCast(SparseT, i);
             }
@@ -162,7 +162,7 @@ pub fn SparseSet(comptime SparseT: type) type {
         pub fn arrange(self: *Self, length: usize, context: anytype, comptime lessThan: fn (@TypeOf(context), SparseT, SparseT) bool, swap_context: anytype) void {
             std.sort.insertionSort(SparseT, self.dense.items[0..length], context, lessThan);
 
-            for (self.dense.items[0..length]) |sparse, pos| {
+            for (self.dense.items[0..length]) |_, pos| {
                 var curr = @intCast(SparseT, pos);
                 var next = self.index(self.dense.items[curr]);
 

--- a/src/ecs/sparse_set.zig
+++ b/src/ecs/sparse_set.zig
@@ -228,15 +228,15 @@ test "add/remove/clear" {
 
     set.add(4);
     set.add(3);
-    std.testing.expectEqual(set.len(), 2);
-    std.testing.expectEqual(set.index(4), 0);
-    std.testing.expectEqual(set.index(3), 1);
+    try std.testing.expectEqual(set.len(), 2);
+    try std.testing.expectEqual(set.index(4), 0);
+    try std.testing.expectEqual(set.index(3), 1);
 
     set.remove(4);
-    std.testing.expectEqual(set.len(), 1);
+    try std.testing.expectEqual(set.len(), 1);
 
     set.clear();
-    std.testing.expectEqual(set.len(), 0);
+    try std.testing.expectEqual(set.len(), 0);
 }
 
 test "grow" {
@@ -248,7 +248,7 @@ test "grow" {
         set.add(@intCast(u32, i));
     }
 
-    std.testing.expectEqual(set.len(), std.math.maxInt(u8));
+    try std.testing.expectEqual(set.len(), std.math.maxInt(u8));
 }
 
 test "swap" {
@@ -257,12 +257,12 @@ test "swap" {
 
     set.add(4);
     set.add(3);
-    std.testing.expectEqual(set.index(4), 0);
-    std.testing.expectEqual(set.index(3), 1);
+    try std.testing.expectEqual(set.index(4), 0);
+    try std.testing.expectEqual(set.index(3), 1);
 
     set.swap(4, 3);
-    std.testing.expectEqual(set.index(3), 0);
-    std.testing.expectEqual(set.index(4), 1);
+    try std.testing.expectEqual(set.index(3), 0);
+    try std.testing.expectEqual(set.index(4), 1);
 }
 
 test "data() synced" {
@@ -275,12 +275,12 @@ test "data() synced" {
     set.add(3);
 
     var data = set.data();
-    std.testing.expectEqual(data[1], 1);
-    std.testing.expectEqual(set.len(), data.len);
+    try std.testing.expectEqual(data[1], 1);
+    try std.testing.expectEqual(set.len(), data.len);
 
     set.remove(0);
     set.remove(1);
-    std.testing.expectEqual(set.len(), set.data().len);
+    try std.testing.expectEqual(set.len(), set.data().len);
 }
 
 test "iterate" {
@@ -295,7 +295,7 @@ test "iterate" {
     var i: u32 = @intCast(u32, set.len()) - 1;
     var iter = set.reverseIterator();
     while (iter.next()) |entity| {
-        std.testing.expectEqual(i, entity);
+        try std.testing.expectEqual(i, entity);
         if (i > 0) i -= 1;
     }
 }
@@ -319,8 +319,8 @@ test "respect 1" {
 
     set1.respect(set2);
 
-    std.testing.expectEqual(set1.dense.items[0], set2.dense.items[1]);
-    std.testing.expectEqual(set1.dense.items[1], set2.dense.items[2]);
+    try std.testing.expectEqual(set1.dense.items[0], set2.dense.items[1]);
+    try std.testing.expectEqual(set1.dense.items[1], set2.dense.items[2]);
 }
 
 const desc_u32 = std.sort.desc(u32);

--- a/src/ecs/type_store.zig
+++ b/src/ecs/type_store.zig
@@ -84,6 +84,6 @@ test "TypeStore" {
     try std.testing.expectEqual(v3.*, 0);
     v3.* = 777;
 
-    var v4 = store.get(u32);
+    _ = store.get(u32);
     try std.testing.expectEqual(v3.*, 777);
 }

--- a/src/ecs/type_store.zig
+++ b/src/ecs/type_store.zig
@@ -67,23 +67,23 @@ test "TypeStore" {
 
     var orig = Vector{ .x = 5, .y = 6, .z = 8 };
     store.add(orig);
-    std.testing.expect(store.has(Vector));
-    std.testing.expectEqual(store.get(Vector).*, orig);
+    try std.testing.expect(store.has(Vector));
+    try std.testing.expectEqual(store.get(Vector).*, orig);
 
     var v = store.get(Vector);
-    std.testing.expectEqual(v.*, Vector{ .x = 5, .y = 6, .z = 8 });
+    try std.testing.expectEqual(v.*, Vector{ .x = 5, .y = 6, .z = 8 });
     v.*.x = 666;
 
     var v2 = store.get(Vector);
-    std.testing.expectEqual(v2.*, Vector{ .x = 666, .y = 6, .z = 8 });
+    try std.testing.expectEqual(v2.*, Vector{ .x = 666, .y = 6, .z = 8 });
 
     store.remove(Vector);
-    std.testing.expect(!store.has(Vector));
+    try std.testing.expect(!store.has(Vector));
 
     var v3 = store.getOrAdd(u32);
-    std.testing.expectEqual(v3.*, 0);
+    try std.testing.expectEqual(v3.*, 0);
     v3.* = 777;
 
     var v4 = store.get(u32);
-    std.testing.expectEqual(v3.*, 777);
+    try std.testing.expectEqual(v3.*, 777);
 }

--- a/src/ecs/type_store.zig
+++ b/src/ecs/type_store.zig
@@ -14,9 +14,9 @@ pub const TypeStore = struct {
     }
 
     pub fn deinit(self: *TypeStore) void {
-        var iter = self.map.iterator();
-        while (iter.next()) |kv| {
-            self.allocator.free(kv.value);
+        var iter = self.map.valueIterator();
+        while (iter.next()) |val_ptr| {
+            self.allocator.free(val_ptr.*);
         }
         self.map.deinit();
     }

--- a/src/ecs/utils.zig
+++ b/src/ecs/utils.zig
@@ -133,7 +133,7 @@ test "ReverseSliceIterator" {
     var iter = ReverseSliceIterator(usize).init(slice);
     var i: usize = 9;
     while (iter.next()) |val| {
-        std.testing.expectEqual(i, val);
+        try std.testing.expectEqual(i, val);
         if (i > 0) i -= 1;
     }
 }

--- a/src/ecs/views.zig
+++ b/src/ecs/views.zig
@@ -135,7 +135,7 @@ pub fn MultiView(comptime n_includes: usize, comptime n_excludes: usize) type {
             }
 
             const asc_usize = struct {
-                fn sort(ctx: void, a: usize, b: usize) bool {
+                fn sort(_: void, a: usize, b: usize) bool {
                     return a < b;
                 }
             };
@@ -235,12 +235,12 @@ test "basic multi view" {
     reg.add(e0, @as(u32, 0));
     reg.add(e2, @as(u32, 2));
 
-    var single_view = reg.view(.{u32}, .{});
+    _ = reg.view(.{u32}, .{});
     var view = reg.view(.{ i32, u32 }, .{});
 
     var iterated_entities: usize = 0;
     var iter = view.iterator();
-    while (iter.next()) |entity| {
+    while (iter.next()) |_| {
         iterated_entities += 1;
     }
 
@@ -250,7 +250,7 @@ test "basic multi view" {
     reg.remove(u32, e0);
 
     iter.reset();
-    while (iter.next()) |entity| {
+    while (iter.next()) |_| {
         iterated_entities += 1;
     }
 
@@ -278,7 +278,7 @@ test "basic multi view with excludes" {
 
     var iterated_entities: usize = 0;
     var iter = view.iterator();
-    while (iter.next()) |entity| {
+    while (iter.next()) |_| {
         iterated_entities += 1;
     }
 
@@ -288,7 +288,7 @@ test "basic multi view with excludes" {
     reg.remove(u8, e2);
 
     iter.reset();
-    while (iter.next()) |entity| {
+    while (iter.next()) |_| {
         iterated_entities += 1;
     }
 

--- a/src/ecs/views.zig
+++ b/src/ecs/views.zig
@@ -159,16 +159,16 @@ test "single basic view" {
     store.add(7, 70);
 
     var view = BasicView(f32).init(&store);
-    std.testing.expectEqual(view.len(), 3);
+    try std.testing.expectEqual(view.len(), 3);
 
     store.remove(7);
-    std.testing.expectEqual(view.len(), 2);
+    try std.testing.expectEqual(view.len(), 2);
 
     var i: usize = 0;
     var iter = view.iterator();
     while (iter.next()) |comp| {
-        if (i == 0) std.testing.expectEqual(comp, 50);
-        if (i == 1) std.testing.expectEqual(comp, 30);
+        if (i == 0) try std.testing.expectEqual(comp, 50);
+        if (i == 1) try std.testing.expectEqual(comp, 30);
         i += 1;
     }
 
@@ -176,12 +176,12 @@ test "single basic view" {
     var entIter = view.entityIterator();
     while (entIter.next()) |ent| {
         if (i == 0) {
-            std.testing.expectEqual(ent, 5);
-            std.testing.expectEqual(view.getConst(ent), 50);
+            try std.testing.expectEqual(ent, 5);
+            try std.testing.expectEqual(view.getConst(ent), 50);
         }
         if (i == 1) {
-            std.testing.expectEqual(ent, 3);
-            std.testing.expectEqual(view.getConst(ent), 30);
+            try std.testing.expectEqual(ent, 3);
+            try std.testing.expectEqual(view.getConst(ent), 30);
         }
         i += 1;
     }
@@ -197,27 +197,27 @@ test "single basic view data" {
 
     var view = BasicView(f32).init(&store);
 
-    std.testing.expectEqual(view.get(3).*, 30);
+    try std.testing.expectEqual(view.get(3).*, 30);
 
     for (view.data()) |entity, i| {
         if (i == 0)
-            std.testing.expectEqual(entity, 3);
+            try std.testing.expectEqual(entity, 3);
         if (i == 1)
-            std.testing.expectEqual(entity, 5);
+            try std.testing.expectEqual(entity, 5);
         if (i == 2)
-            std.testing.expectEqual(entity, 7);
+            try std.testing.expectEqual(entity, 7);
     }
 
     for (view.raw()) |data, i| {
         if (i == 0)
-            std.testing.expectEqual(data, 30);
+            try std.testing.expectEqual(data, 30);
         if (i == 1)
-            std.testing.expectEqual(data, 50);
+            try std.testing.expectEqual(data, 50);
         if (i == 2)
-            std.testing.expectEqual(data, 70);
+            try std.testing.expectEqual(data, 70);
     }
 
-    std.testing.expectEqual(view.len(), 3);
+    try std.testing.expectEqual(view.len(), 3);
 }
 
 test "basic multi view" {
@@ -244,7 +244,7 @@ test "basic multi view" {
         iterated_entities += 1;
     }
 
-    std.testing.expectEqual(iterated_entities, 2);
+    try std.testing.expectEqual(iterated_entities, 2);
     iterated_entities = 0;
 
     reg.remove(u32, e0);
@@ -254,7 +254,7 @@ test "basic multi view" {
         iterated_entities += 1;
     }
 
-    std.testing.expectEqual(iterated_entities, 1);
+    try std.testing.expectEqual(iterated_entities, 1);
 }
 
 test "basic multi view with excludes" {
@@ -282,7 +282,7 @@ test "basic multi view with excludes" {
         iterated_entities += 1;
     }
 
-    std.testing.expectEqual(iterated_entities, 1);
+    try std.testing.expectEqual(iterated_entities, 1);
     iterated_entities = 0;
 
     reg.remove(u8, e2);
@@ -292,5 +292,5 @@ test "basic multi view with excludes" {
         iterated_entities += 1;
     }
 
-    std.testing.expectEqual(iterated_entities, 2);
+    try std.testing.expectEqual(iterated_entities, 2);
 }

--- a/src/process/scheduler.zig
+++ b/src/process/scheduler.zig
@@ -149,27 +149,27 @@ test "" {
         }
 
         fn start(process: *Process) void {
-            const self = process.getParent(@This());
+            _ = process.getParent(@This());
             // std.debug.warn("start {}\n", .{self.fart});
         }
 
         fn aborted(process: *Process) void {
-            const self = process.getParent(@This());
+            _ = process.getParent(@This());
             // std.debug.warn("aborted {}\n", .{self.fart});
         }
 
         fn failed(process: *Process) void {
-            const self = process.getParent(@This());
+            _ = process.getParent(@This());
             // std.debug.warn("failed {}\n", .{self.fart});
         }
 
         fn succeeded(process: *Process) void {
-            const self = process.getParent(@This());
+            _ = process.getParent(@This());
             // std.debug.warn("succeeded {}\n", .{self.fart});
         }
 
         fn update(process: *Process) void {
-            const self = process.getParent(@This());
+            _ = process.getParent(@This());
             // std.debug.warn("update {}\n", .{self.fart});
             process.succeed();
         }
@@ -190,11 +190,11 @@ test "scheduler.clear" {
     const Tester = struct {
         process: Process,
 
-        pub fn initialize(self: *@This(), data: anytype) void {
+        pub fn initialize(self: *@This(), _: anytype) void {
             self.process = .{ .updateFn = update };
         }
 
-        fn update(process: *Process) void {
+        fn update(_: *Process) void {
             std.debug.assert(false);
         }
     };

--- a/src/process/scheduler.zig
+++ b/src/process/scheduler.zig
@@ -231,5 +231,5 @@ test "scheduler.attach.next" {
     _ = scheduler.attach(Tester, &counter).next(Tester, &counter);
     scheduler.update();
     scheduler.update();
-    std.testing.expectEqual(counter, 2);
+    try std.testing.expectEqual(counter, 2);
 }

--- a/src/resources/assets.zig
+++ b/src/resources/assets.zig
@@ -62,13 +62,13 @@ test "assets" {
     };
 
     const OtherThingLoadArgs = struct {
-        pub fn load(self: @This()) *OtherThing {
+        pub fn load(_: @This()) *OtherThing {
             return std.testing.allocator.create(OtherThing) catch unreachable;
         }
     };
 
     const ThingLoadArgs = struct {
-        pub fn load(self: @This()) *Thing {
+        pub fn load(_: @This()) *Thing {
             return std.testing.allocator.create(Thing) catch unreachable;
         }
     };
@@ -76,16 +76,16 @@ test "assets" {
     var assets = Assets.init(std.testing.allocator);
     defer assets.deinit();
 
-    var thing = assets.get(Thing).load(6, ThingLoadArgs{});
+    _ = assets.get(Thing).load(6, ThingLoadArgs{});
     try std.testing.expectEqual(assets.get(Thing).size(), 1);
 
-    var thing2 = assets.load(4, ThingLoadArgs{});
+    _ = assets.load(4, ThingLoadArgs{});
     try std.testing.expectEqual(assets.get(Thing).size(), 2);
 
-    var other_thing = assets.get(OtherThing).load(6, OtherThingLoadArgs{});
+    _ = assets.get(OtherThing).load(6, OtherThingLoadArgs{});
     try std.testing.expectEqual(assets.get(OtherThing).size(), 1);
 
-    var other_thing2 = assets.load(8, OtherThingLoadArgs{});
+    _ = assets.load(8, OtherThingLoadArgs{});
     try std.testing.expectEqual(assets.get(OtherThing).size(), 2);
 
     assets.get(OtherThing).clear();

--- a/src/resources/assets.zig
+++ b/src/resources/assets.zig
@@ -17,7 +17,7 @@ pub const Assets = struct {
         var iter = self.caches.iterator();
         while (iter.next()) |ptr| {
             // HACK: we dont know the Type here but we need to call deinit
-            @intToPtr(*Cache(u1), ptr.value).deinit();
+            @intToPtr(*Cache(u1), ptr.value_ptr.*).deinit();
         }
 
         self.caches.deinit();
@@ -77,17 +77,17 @@ test "assets" {
     defer assets.deinit();
 
     var thing = assets.get(Thing).load(6, ThingLoadArgs{});
-    std.testing.expectEqual(assets.get(Thing).size(), 1);
+    try std.testing.expectEqual(assets.get(Thing).size(), 1);
 
     var thing2 = assets.load(4, ThingLoadArgs{});
-    std.testing.expectEqual(assets.get(Thing).size(), 2);
+    try std.testing.expectEqual(assets.get(Thing).size(), 2);
 
     var other_thing = assets.get(OtherThing).load(6, OtherThingLoadArgs{});
-    std.testing.expectEqual(assets.get(OtherThing).size(), 1);
+    try std.testing.expectEqual(assets.get(OtherThing).size(), 1);
 
     var other_thing2 = assets.load(8, OtherThingLoadArgs{});
-    std.testing.expectEqual(assets.get(OtherThing).size(), 2);
+    try std.testing.expectEqual(assets.get(OtherThing).size(), 2);
 
     assets.get(OtherThing).clear();
-    std.testing.expectEqual(assets.get(OtherThing).size(), 0);
+    try std.testing.expectEqual(assets.get(OtherThing).size(), 0);
 }

--- a/src/resources/cache.zig
+++ b/src/resources/cache.zig
@@ -57,7 +57,7 @@ pub fn Cache(comptime T: type) type {
         }
 
         pub fn remove(self: *@This(), id: u32) void {
-            if (self.resources.remove(id)) |kv| {
+            if (self.resources.fetchRemove(id)) |kv| {
                 if (@hasDecl(T, "deinit")) {
                     @call(.{ .modifier = .always_inline }, @field(kv.value, "deinit"), .{});
                 }
@@ -69,7 +69,7 @@ pub fn Cache(comptime T: type) type {
             if (@hasDecl(T, "deinit")) {
                 var iter = self.resources.iterator();
                 while (iter.next()) |kv| {
-                    @call(.{ .modifier = .always_inline }, @field(kv.value, "deinit"), .{});
+                    @call(.{ .modifier = .always_inline }, @field(kv.value_ptr.*, "deinit"), .{});
                 }
             }
             self.resources.clearAndFree();
@@ -102,11 +102,11 @@ test "cache" {
 
     var thing = cache.load(utils.hashString("my/id"), ThingLoadArgs{});
     var thing2 = cache.load(utils.hashString("another/id"), ThingLoadArgs{});
-    std.testing.expectEqual(cache.size(), 2);
+    try std.testing.expectEqual(cache.size(), 2);
 
     cache.remove(utils.hashString("my/id"));
-    std.testing.expectEqual(cache.size(), 1);
+    try std.testing.expectEqual(cache.size(), 1);
 
     cache.clear();
-    std.testing.expectEqual(cache.size(), 0);
+    try std.testing.expectEqual(cache.size(), 0);
 }

--- a/src/resources/cache.zig
+++ b/src/resources/cache.zig
@@ -93,6 +93,7 @@ test "cache" {
 
     const ThingLoadArgs = struct {
         pub fn load(self: @This()) *Thing {
+            _ = self;
             return std.testing.allocator.create(Thing) catch unreachable;
         }
     };
@@ -100,8 +101,8 @@ test "cache" {
     var cache = Cache(Thing).init(std.testing.allocator);
     defer cache.deinit();
 
-    var thing = cache.load(utils.hashString("my/id"), ThingLoadArgs{});
-    var thing2 = cache.load(utils.hashString("another/id"), ThingLoadArgs{});
+    _ = cache.load(utils.hashString("my/id"), ThingLoadArgs{});
+    _ = cache.load(utils.hashString("another/id"), ThingLoadArgs{});
     try std.testing.expectEqual(cache.size(), 2);
 
     cache.remove(utils.hashString("my/id"));

--- a/src/signals/delegate.zig
+++ b/src/signals/delegate.zig
@@ -69,7 +69,7 @@ fn tester(param: u32) void {
 const Thing = struct {
     field: f32 = 0,
 
-    pub fn tester(self: *Thing, param: u32) void {
+    pub fn tester(_: *Thing, param: u32) void {
         std.testing.expectEqual(@as(u32, 777), param) catch unreachable;
     }
 };

--- a/src/signals/delegate.zig
+++ b/src/signals/delegate.zig
@@ -63,14 +63,14 @@ pub fn Delegate(comptime Event: type) type {
 }
 
 fn tester(param: u32) void {
-    std.testing.expectEqual(@as(u32, 666), param);
+    std.testing.expectEqual(@as(u32, 666), param) catch unreachable;
 }
 
 const Thing = struct {
     field: f32 = 0,
 
     pub fn tester(self: *Thing, param: u32) void {
-        std.testing.expectEqual(@as(u32, 777), param);
+        std.testing.expectEqual(@as(u32, 777), param) catch unreachable;
     }
 };
 

--- a/src/signals/dispatcher.zig
+++ b/src/signals/dispatcher.zig
@@ -18,7 +18,7 @@ pub const Dispatcher = struct {
         var iter = self.signals.iterator();
         while (iter.next()) |ptr| {
             // HACK: we dont know the Type here but we need to call deinit
-            var signal = @intToPtr(*Signal(void), ptr.value);
+            var signal = @intToPtr(*Signal(void), ptr.value_ptr.*);
             signal.deinit();
         }
 

--- a/src/signals/signal.zig
+++ b/src/signals/signal.zig
@@ -64,7 +64,7 @@ fn tester(param: u32) void {
 const Thing = struct {
     field: f32 = 0,
 
-    pub fn tester(self: *Thing, param: u32) void {
+    pub fn tester(_: *Thing, param: u32) void {
         std.testing.expectEqual(@as(u32, 666), param) catch unreachable;
     }
 };

--- a/src/signals/signal.zig
+++ b/src/signals/signal.zig
@@ -58,14 +58,14 @@ pub fn Signal(comptime Event: type) type {
 }
 
 fn tester(param: u32) void {
-    std.testing.expectEqual(@as(u32, 666), param);
+    std.testing.expectEqual(@as(u32, 666), param) catch unreachable;
 }
 
 const Thing = struct {
     field: f32 = 0,
 
     pub fn tester(self: *Thing, param: u32) void {
-        std.testing.expectEqual(@as(u32, 666), param);
+        std.testing.expectEqual(@as(u32, 666), param) catch unreachable;
     }
 };
 
@@ -75,7 +75,7 @@ test "Signal/Sink" {
 
     var sink = signal.sink();
     sink.connect(tester);
-    std.testing.expectEqual(@as(usize, 1), signal.size());
+    try std.testing.expectEqual(@as(usize, 1), signal.size());
 
     // bound listener
     var thing = Thing{};
@@ -85,10 +85,10 @@ test "Signal/Sink" {
 
     sink.disconnect(tester);
     signal.publish(666);
-    std.testing.expectEqual(@as(usize, 1), signal.size());
+    try std.testing.expectEqual(@as(usize, 1), signal.size());
 
     sink.disconnectBound(&thing);
-    std.testing.expectEqual(@as(usize, 0), signal.size());
+    try std.testing.expectEqual(@as(usize, 0), signal.size());
 }
 
 test "Sink Before null" {
@@ -97,9 +97,9 @@ test "Sink Before null" {
 
     var sink = signal.sink();
     sink.connect(tester);
-    std.testing.expectEqual(@as(usize, 1), signal.size());
+    try std.testing.expectEqual(@as(usize, 1), signal.size());
 
     var thing = Thing{};
     sink.before(null).connectBound(&thing, "tester");
-    std.testing.expectEqual(@as(usize, 2), signal.size());
+    try std.testing.expectEqual(@as(usize, 2), signal.size());
 }

--- a/src/signals/sink.zig
+++ b/src/signals/sink.zig
@@ -79,14 +79,14 @@ pub fn Sink(comptime Event: type) type {
 }
 
 fn tester(param: u32) void {
-    std.testing.expectEqual(@as(u32, 666), param);
+    std.testing.expectEqual(@as(u32, 666), param) catch unreachable;
 }
 
 const Thing = struct {
     field: f32 = 0,
 
     pub fn tester(self: *Thing, param: u32) void {
-        std.testing.expectEqual(@as(u32, 666), param);
+        std.testing.expectEqual(@as(u32, 666), param) catch unreachable;
     }
 };
 
@@ -95,11 +95,11 @@ test "Sink Before free" {
     defer signal.deinit();
 
     signal.sink().connect(tester);
-    std.testing.expectEqual(signal.sink().indexOf(tester).?, 0);
+    try std.testing.expectEqual(signal.sink().indexOf(tester).?, 0);
 
     var thing = Thing{};
     signal.sink().before(tester).connectBound(&thing, "tester");
-    std.testing.expectEqual(signal.sink().indexOfBound(&thing).?, 0);
+    try std.testing.expectEqual(signal.sink().indexOfBound(&thing).?, 0);
 }
 
 test "Sink Before bound" {
@@ -108,8 +108,8 @@ test "Sink Before bound" {
 
     var thing = Thing{};
     signal.sink().connectBound(&thing, "tester");
-    std.testing.expectEqual(signal.sink().indexOfBound(&thing).?, 0);
+    try std.testing.expectEqual(signal.sink().indexOfBound(&thing).?, 0);
 
     signal.sink().beforeBound(&thing).connect(tester);
-    std.testing.expectEqual(signal.sink().indexOf(tester).?, 0);
+    try std.testing.expectEqual(signal.sink().indexOf(tester).?, 0);
 }

--- a/src/signals/sink.zig
+++ b/src/signals/sink.zig
@@ -58,7 +58,7 @@ pub fn Sink(comptime Event: type) type {
             }
         }
 
-        fn indexOf(self: Self, callback: fn (Event) void) ?usize {
+        fn indexOf(_: Self, callback: fn (Event) void) ?usize {
             for (owning_signal.calls.items) |call, i| {
                 if (call.containsFree(callback)) {
                     return i;
@@ -67,7 +67,7 @@ pub fn Sink(comptime Event: type) type {
             return null;
         }
 
-        fn indexOfBound(self: Self, ctx: anytype) ?usize {
+        fn indexOfBound(_: Self, ctx: anytype) ?usize {
             for (owning_signal.calls.items) |call, i| {
                 if (call.containsBound(ctx)) {
                     return i;
@@ -85,7 +85,7 @@ fn tester(param: u32) void {
 const Thing = struct {
     field: f32 = 0,
 
-    pub fn tester(self: *Thing, param: u32) void {
+    pub fn tester(_: *Thing, param: u32) void {
         std.testing.expectEqual(@as(u32, 666), param) catch unreachable;
     }
 };

--- a/tests/dispatcher_test.zig
+++ b/tests/dispatcher_test.zig
@@ -2,22 +2,22 @@ const std = @import("std");
 const Dispatcher = @import("ecs").Dispatcher;
 
 fn tester(param: u32) void {
-    std.testing.expectEqual(@as(u32, 666), param);
+    std.testing.expectEqual(@as(u32, 666), param) catch unreachable;
 }
 
 fn tester2(param: i32) void {
-    std.testing.expectEqual(@as(i32, -543), param);
+    std.testing.expectEqual(@as(i32, -543), param) catch unreachable;
 }
 
 const Thing = struct {
     field: f32 = 0,
 
     pub fn testU32(self: *Thing, param: u32) void {
-        std.testing.expectEqual(@as(u32, 666), param);
+        std.testing.expectEqual(@as(u32, 666), param) catch unreachable;
     }
 
     pub fn testI32(self: *Thing, param: i32) void {
-        std.testing.expectEqual(@as(i32, -543), param);
+        std.testing.expectEqual(@as(i32, -543), param) catch unreachable;
     }
 };
 

--- a/tests/dispatcher_test.zig
+++ b/tests/dispatcher_test.zig
@@ -12,11 +12,11 @@ fn tester2(param: i32) void {
 const Thing = struct {
     field: f32 = 0,
 
-    pub fn testU32(self: *Thing, param: u32) void {
+    pub fn testU32(_: *Thing, param: u32) void {
         std.testing.expectEqual(@as(u32, 666), param) catch unreachable;
     }
 
-    pub fn testI32(self: *Thing, param: i32) void {
+    pub fn testI32(_: *Thing, param: i32) void {
         std.testing.expectEqual(@as(i32, -543), param) catch unreachable;
     }
 };

--- a/tests/groups_test.zig
+++ b/tests/groups_test.zig
@@ -51,7 +51,7 @@ test "sort BasicGroup by Entity" {
     var val: f32 = 0;
     var iter = group.iterator();
     while (iter.next()) |entity| {
-        std.testing.expectEqual(val, group.getConst(Sprite, entity).x);
+        try std.testing.expectEqual(val, group.getConst(Sprite, entity).x);
         val += 1;
     }
 }
@@ -79,7 +79,7 @@ test "sort BasicGroup by Component" {
     var val: f32 = 0;
     var iter = group.iterator();
     while (iter.next()) |entity| {
-        std.testing.expectEqual(val, group.getConst(Sprite, entity).x);
+        try std.testing.expectEqual(val, group.getConst(Sprite, entity).x);
         val += 1;
     }
 }
@@ -112,7 +112,7 @@ test "sort OwningGroup by Entity" {
     var val: f32 = 0;
     var iter = group.iterator(struct { s: *Sprite, r: *Renderable });
     while (iter.next()) |entity| {
-        std.testing.expectEqual(val, entity.s.*.x);
+        try std.testing.expectEqual(val, entity.s.*.x);
         val += 1;
     }
 }
@@ -140,7 +140,7 @@ test "sort OwningGroup by Component" {
     var val: f32 = 0;
     var iter = group.iterator(struct { s: *Sprite, r: *Renderable });
     while (iter.next()) |entity| {
-        std.testing.expectEqual(val, entity.s.*.x);
+        try std.testing.expectEqual(val, entity.s.*.x);
         val += 1;
     }
 }
@@ -161,13 +161,13 @@ test "sort OwningGroup by Component ensure unsorted non-matches" {
         reg.add(e2, Sprite{ .x = @intToFloat(f32, i + 1 * 50) });
     }
 
-    std.testing.expectEqual(group.len(), 5);
-    std.testing.expectEqual(reg.len(Sprite), 10);
+    try std.testing.expectEqual(group.len(), 5);
+    try std.testing.expectEqual(reg.len(Sprite), 10);
 
     const SortContext = struct {
         fn sort(this: void, a: Sprite, b: Sprite) bool {
             // sprites with x > 50 shouldnt match in the group
-            std.testing.expect(a.x < 50 and b.x < 50);
+            std.testing.expect(a.x < 50 and b.x < 50) catch unreachable;
             return a.x > b.x;
         }
     };
@@ -182,7 +182,7 @@ test "sort OwningGroup by Component ensure unsorted non-matches" {
 
         // all sprite.x > 50 should be at the end and we iterate backwards
         if (count < 6) {
-            std.testing.expect(sprite.x >= 50);
+            try std.testing.expect(sprite.x >= 50);
         }
     }
 }
@@ -195,23 +195,23 @@ test "nested OwningGroups add/remove components" {
     var group2 = reg.group(.{ Sprite, Transform }, .{Renderable}, .{});
     var group3 = reg.group(.{ Sprite, Transform }, .{ Renderable, Rotation }, .{});
 
-    std.testing.expect(!reg.sortable(Sprite));
-    std.testing.expect(!reg.sortable(Transform));
-    std.testing.expect(reg.sortable(Renderable));
+    try std.testing.expect(!reg.sortable(Sprite));
+    try std.testing.expect(!reg.sortable(Transform));
+    try std.testing.expect(reg.sortable(Renderable));
 
     var e1 = reg.create();
     reg.addTypes(e1, .{ Sprite, Renderable, Rotation });
-    std.testing.expectEqual(group1.len(), 1);
-    std.testing.expectEqual(group2.len(), 0);
-    std.testing.expectEqual(group3.len(), 0);
+    try std.testing.expectEqual(group1.len(), 1);
+    try std.testing.expectEqual(group2.len(), 0);
+    try std.testing.expectEqual(group3.len(), 0);
 
     reg.add(e1, Transform{});
-    std.testing.expectEqual(group3.len(), 1);
+    try std.testing.expectEqual(group3.len(), 1);
 
     reg.remove(Sprite, e1);
-    std.testing.expectEqual(group1.len(), 0);
-    std.testing.expectEqual(group2.len(), 0);
-    std.testing.expectEqual(group3.len(), 0);
+    try std.testing.expectEqual(group1.len(), 0);
+    try std.testing.expectEqual(group2.len(), 0);
+    try std.testing.expectEqual(group3.len(), 0);
 }
 
 test "nested OwningGroups entity order" {
@@ -228,8 +228,8 @@ test "nested OwningGroups entity order" {
         reg.add(e, Renderable{ .x = @intToFloat(f32, i) });
     }
 
-    std.testing.expectEqual(group1.len(), 5);
-    std.testing.expectEqual(group2.len(), 0);
+    try std.testing.expectEqual(group1.len(), 5);
+    try std.testing.expectEqual(group2.len(), 0);
 
     var sprite_store = reg.assure(Sprite);
     var transform_store = reg.assure(Transform);

--- a/tests/groups_test.zig
+++ b/tests/groups_test.zig
@@ -70,7 +70,7 @@ test "sort BasicGroup by Component" {
     }
 
     const SortContext = struct {
-        fn sort(this: void, a: Sprite, b: Sprite) bool {
+        fn sort(_: void, a: Sprite, b: Sprite) bool {
             return a.x > b.x;
         }
     };
@@ -131,7 +131,7 @@ test "sort OwningGroup by Component" {
     }
 
     const SortContext = struct {
-        fn sort(this: void, a: Sprite, b: Sprite) bool {
+        fn sort(_: void, a: Sprite, b: Sprite) bool {
             return a.x > b.x;
         }
     };
@@ -165,7 +165,7 @@ test "sort OwningGroup by Component ensure unsorted non-matches" {
     try std.testing.expectEqual(reg.len(Sprite), 10);
 
     const SortContext = struct {
-        fn sort(this: void, a: Sprite, b: Sprite) bool {
+        fn sort(_: void, a: Sprite, b: Sprite) bool {
             // sprites with x > 50 shouldnt match in the group
             std.testing.expect(a.x < 50 and b.x < 50) catch unreachable;
             return a.x > b.x;
@@ -231,8 +231,8 @@ test "nested OwningGroups entity order" {
     try std.testing.expectEqual(group1.len(), 5);
     try std.testing.expectEqual(group2.len(), 0);
 
-    var sprite_store = reg.assure(Sprite);
-    var transform_store = reg.assure(Transform);
+    _ = reg.assure(Sprite);
+    _ = reg.assure(Transform);
     // printStore(sprite_store, "Sprite");
 
     reg.add(1, Transform{ .x = 1 });

--- a/tests/registry_test.zig
+++ b/tests/registry_test.zig
@@ -8,7 +8,7 @@ const Empty = struct {};
 const BigOne = struct { pos: Position, vel: Velocity, accel: Velocity };
 
 test "entity traits" {
-    const traits = ecs.EntityTraitsType(.large).init();
+    _ = ecs.EntityTraitsType(.large).init();
 }
 
 test "Registry" {
@@ -54,6 +54,7 @@ test "context not pointer" {
     defer reg.deinit();
 
     var pos = Position{ .x = 5, .y = 5 };
+    _ = pos;
     // reg.setContext(pos);
 }
 

--- a/tests/registry_test.zig
+++ b/tests/registry_test.zig
@@ -20,15 +20,15 @@ test "Registry" {
     reg.addTypes(e1, .{ Empty, Position });
     reg.add(e1, BigOne{ .pos = Position{ .x = 5, .y = 5 }, .vel = Velocity{ .x = 5, .y = 5 }, .accel = Velocity{ .x = 5, .y = 5 } });
 
-    std.testing.expect(reg.has(Empty, e1));
-    std.testing.expect(reg.has(Position, e1));
-    std.testing.expect(reg.has(BigOne, e1));
+    try std.testing.expect(reg.has(Empty, e1));
+    try std.testing.expect(reg.has(Position, e1));
+    try std.testing.expect(reg.has(BigOne, e1));
 
     var iter = reg.entities();
-    while (iter.next()) |e| std.testing.expectEqual(e1, e);
+    while (iter.next()) |e| try std.testing.expectEqual(e1, e);
 
     reg.remove(Empty, e1);
-    std.testing.expect(!reg.has(Empty, e1));
+    try std.testing.expect(!reg.has(Empty, e1));
 }
 
 test "context get/set/unset" {
@@ -36,16 +36,16 @@ test "context get/set/unset" {
     defer reg.deinit();
 
     var ctx = reg.getContext(Position);
-    std.testing.expectEqual(ctx, null);
+    try std.testing.expectEqual(ctx, null);
 
     var pos = Position{ .x = 5, .y = 5 };
     reg.setContext(&pos);
     ctx = reg.getContext(Position);
-    std.testing.expectEqual(ctx.?, &pos);
+    try std.testing.expectEqual(ctx.?, &pos);
 
     reg.unsetContext(Position);
     ctx = reg.getContext(Position);
-    std.testing.expectEqual(ctx, null);
+    try std.testing.expectEqual(ctx, null);
 }
 
 // this test should fail
@@ -64,16 +64,16 @@ test "context get/set/unset" {
     defer reg.deinit();
 
     var ctx = reg.getContext(SomeType);
-    std.testing.expectEqual(ctx, null);
+    try std.testing.expectEqual(ctx, null);
 
     var pos = SomeType{ .dummy = 0 };
     reg.setContext(&pos);
     ctx = reg.getContext(SomeType);
-    std.testing.expectEqual(ctx.?, &pos);
+    try std.testing.expectEqual(ctx.?, &pos);
 
     reg.unsetContext(SomeType);
     ctx = reg.getContext(SomeType);
-    std.testing.expectEqual(ctx, null);
+    try std.testing.expectEqual(ctx, null);
 }
 
 test "singletons" {
@@ -82,11 +82,11 @@ test "singletons" {
 
     var pos = Position{ .x = 5, .y = 5 };
     reg.singletons.add(pos);
-    std.testing.expect(reg.singletons.has(Position));
-    std.testing.expectEqual(reg.singletons.get(Position).*, pos);
+    try std.testing.expect(reg.singletons.has(Position));
+    try std.testing.expectEqual(reg.singletons.get(Position).*, pos);
 
     reg.singletons.remove(Position);
-    std.testing.expect(!reg.singletons.has(Position));
+    try std.testing.expect(!reg.singletons.has(Position));
 }
 
 test "destroy" {
@@ -105,7 +105,7 @@ test "destroy" {
     i = 0;
     while (i < 6) : (i += 1) {
         if (i != 3 and i != 4)
-            std.testing.expectEqual(Position{ .x = @intToFloat(f32, i), .y = @intToFloat(f32, i) }, reg.getConst(Position, i));
+            try std.testing.expectEqual(Position{ .x = @intToFloat(f32, i), .y = @intToFloat(f32, i) }, reg.getConst(Position, i));
     }
 }
 
@@ -117,11 +117,11 @@ test "remove all" {
     reg.add(e, Position{ .x = 1, .y = 1 });
     reg.addTyped(u32, e, 666);
 
-    std.testing.expect(reg.has(Position, e));
-    std.testing.expect(reg.has(u32, e));
+    try std.testing.expect(reg.has(Position, e));
+    try std.testing.expect(reg.has(u32, e));
 
     reg.removeAll(e);
 
-    std.testing.expect(!reg.has(Position, e));
-    std.testing.expect(!reg.has(u32, e));
+    try std.testing.expect(!reg.has(Position, e));
+    try std.testing.expect(!reg.has(u32, e));
 }


### PR DESCRIPTION
Some of the major changes this version:

- HashMap iterator has been changed. I fixed these error in the first commit.
- Testing has switched from panicking to gathering a list of error values. Updating to this will mostly require adding `try` in front of `std.testing.expectX`, but it will also require any tester functions to be updated to return error codes. This has not been fixed in this pull request at the moment.