### PR TITLE
Resolve use of undeclared identifier 'slice' error

### DIFF
--- a/src/ecs/utils.zig
+++ b/src/ecs/utils.zig
@@ -43,7 +43,7 @@ pub fn ReverseSliceIterator(comptime T: type) type {
         }
 
         pub fn reset(self: *@This()) void {
-            self.index = slice.len;
+            self.index = self.slice.len;
         }
     };
 }


### PR DESCRIPTION
Using reset() from the ReverseSliceIterator struct in utils.zig results in the following error
```
error: use of undeclared identifier 'slice'
            self.index = slice.len;
```
Added self. to the slice variable to resolve the error.