### PR TITLE
Update to latest zig release 0.11.0-dev.2964+e9cbdb2cf

### DIFF
--- a/src/ecs/component_storage.zig
+++ b/src/ecs/component_storage.zig
@@ -326,7 +326,7 @@ test "iterate" {
     store.add(5, 66.45);
     store.add(7, 66.45);
 
-    for (store.data()) |entity, i| {
+    for (store.data(), 0..) |entity, i| {
         if (i == 0) {
             try std.testing.expectEqual(entity, 3);
         }
@@ -392,7 +392,7 @@ test "sort empty component" {
 
     const asc_u32 = comptime std.sort.asc(u32);
     store.sort(u32, {}, asc_u32);
-    for (store.data()) |e, i| {
+    for (store.data(), 0..) |e, i| {
         try std.testing.expectEqual(@intCast(u32, i), e);
     }
 

--- a/src/ecs/entity.zig
+++ b/src/ecs/entity.zig
@@ -17,17 +17,17 @@ fn EntityTraitsDefinition(comptime EntityType: type, comptime IndexType: type, c
     std.debug.assert(std.meta.trait.isUnsignedInt(EntityType));
     std.debug.assert(std.meta.trait.isUnsignedInt(IndexType));
     std.debug.assert(std.meta.trait.isUnsignedInt(VersionType));
-    
+
     const sizeOfIndexType = @bitSizeOf(IndexType);
     const sizeOfVersionType = @bitSizeOf(VersionType);
     const entityShift = sizeOfIndexType;
-    
+
     if (sizeOfIndexType + sizeOfVersionType != @bitSizeOf(EntityType))
         @compileError("IndexType and VersionType must sum to EntityType's bit count");
 
     const entityMask = std.math.maxInt(IndexType);
     const versionMask = std.math.maxInt(VersionType);
-    
+
     return struct {
         entity_type: type = EntityType,
         index_type: type = IndexType,

--- a/src/ecs/groups.zig
+++ b/src/ecs/groups.zig
@@ -85,7 +85,7 @@ pub const OwningGroup = struct {
                 const component_info = @typeInfo(Components).Struct;
 
                 var component_ptrs: [component_info.fields.len][*]u8 = undefined;
-                inline for (component_info.fields) |field, i| {
+                inline for (component_info.fields, 0..) |field, i| {
                     const storage = group.registry.assure(@typeInfo(field.type).Pointer.child);
                     component_ptrs[i] = @ptrCast([*]u8, storage.instances.items.ptr);
                 }
@@ -104,7 +104,7 @@ pub const OwningGroup = struct {
 
                 // fill and return the struct
                 var comps: Components = undefined;
-                inline for (@typeInfo(Components).Struct.fields) |field, i| {
+                inline for (@typeInfo(Components).Struct.fields, 0..) |field, i| {
                     const typed_ptr = @ptrCast([*]@typeInfo(field.type).Pointer.child, @alignCast(@alignOf(@typeInfo(field.type).Pointer.child), it.component_ptrs[i]));
                     @field(comps, field.name) = &typed_ptr[it.index];
                 }
@@ -173,7 +173,7 @@ pub const OwningGroup = struct {
         const component_info = @typeInfo(Components).Struct;
 
         var component_ptrs: [component_info.fields.len][*]u8 = undefined;
-        inline for (component_info.fields) |field, i| {
+        inline for (component_info.fields, 0..) |field, i| {
             const storage = self.registry.assure(std.meta.Child(field.type));
             component_ptrs[i] = @ptrCast([*]u8, storage.instances.items.ptr);
         }
@@ -181,7 +181,7 @@ pub const OwningGroup = struct {
         // fill the struct
         const index = self.firstOwnedStorage().set.index(entity);
         var comps: Components = undefined;
-        inline for (component_info.fields) |field, i| {
+        inline for (component_info.fields, 0..) |field, i| {
             const typed_ptr = @ptrCast([*]std.meta.Child(field.type), @alignCast(@alignOf(std.meta.Child(field.type)), component_ptrs[i]));
             @field(comps, field.name) = &typed_ptr[index];
         }
@@ -191,8 +191,7 @@ pub const OwningGroup = struct {
 
     pub fn each(self: OwningGroup, comptime func: anytype) void {
         const Components = switch (@typeInfo(@TypeOf(func))) {
-            .BoundFn => |func_info| func_info.args[1].arg_type.?,
-            .Fn => |func_info| func_info.args[0].arg_type.?,
+            .Fn => |func_info| func_info.params[0].type.?,
             else => std.debug.assert("invalid func"),
         };
         self.validate(Components);

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -146,7 +146,7 @@ pub const Registry = struct {
         /// which ensures more specialized (ie less matches) will always be swapping inside the bounds of
         /// the less specialized groups.
         fn findInsertionIndex(self: GroupData, groups: []*GroupData) ?usize {
-            for (groups) |grp, i| {
+            for (groups, 0..) |grp, i| {
                 var overlapping: u8 = 0;
                 for (grp.owned) |grp_owned| {
                     if (std.mem.indexOfScalar(u32, self.owned, grp_owned)) |_| overlapping += 1;
@@ -443,13 +443,13 @@ pub const Registry = struct {
             return BasicView(includes[0]).init(self.assure(includes[0]));
 
         var includes_arr: [includes.len]u32 = undefined;
-        inline for (includes) |t, i| {
+        inline for (includes, 0..) |t, i| {
             _ = self.assure(t);
             includes_arr[i] = utils.typeId(t);
         }
 
         var excludes_arr: [excludes.len]u32 = undefined;
-        inline for (excludes) |t, i| {
+        inline for (excludes, 0..) |t, i| {
             _ = self.assure(t);
             excludes_arr[i] = utils.typeId(t);
         }
@@ -486,19 +486,19 @@ pub const Registry = struct {
 
         // gather up all our Types as typeIds
         var includes_arr: [includes.len]u32 = undefined;
-        inline for (includes) |t, i| {
+        inline for (includes, 0..) |t, i| {
             _ = self.assure(t);
             includes_arr[i] = utils.typeId(t);
         }
 
         var excludes_arr: [excludes.len]u32 = undefined;
-        inline for (excludes) |t, i| {
+        inline for (excludes, 0..) |t, i| {
             _ = self.assure(t);
             excludes_arr[i] = utils.typeId(t);
         }
 
         var owned_arr: [owned.len]u32 = undefined;
-        inline for (owned) |t, i| {
+        inline for (owned, 0..) |t, i| {
             _ = self.assure(t);
             owned_arr[i] = utils.typeId(t);
         }
@@ -628,7 +628,7 @@ pub const Registry = struct {
             };
 
             var names: [types.len][]const u8 = undefined;
-            for (names) |*name, i| {
+            for (&names, 0..) |*name, i| {
                 name.* = @typeName(types[i]);
             }
 

--- a/src/ecs/utils.zig
+++ b/src/ecs/utils.zig
@@ -81,12 +81,12 @@ pub fn sortSubSub(comptime T1: type, comptime T2: type, items: []T1, sub_items: 
 
 /// comptime string hashing for the type names
 pub fn typeId(comptime T: type) u32 {
-    comptime return hashStringFnv(u32, @typeName(T));
+    return hashStringFnv(u32, @typeName(T));
 }
 
 /// comptime string hashing for the type names
 pub fn typeId64(comptime T: type) u64 {
-    comptime return hashStringFnv(u64, @typeName(T));
+    return hashStringFnv(u64, @typeName(T));
 }
 
 /// u32 Fowler-Noll-Vo string hash
@@ -126,7 +126,7 @@ test "ReverseSliceIterator" {
     var slice = std.testing.allocator.alloc(usize, 10) catch unreachable;
     defer std.testing.allocator.free(slice);
 
-    for (slice) |*item, i| {
+    for (slice, 0..) |*item, i| {
         item.* = i;
     }
 

--- a/src/ecs/views.zig
+++ b/src/ecs/views.zig
@@ -69,10 +69,7 @@ pub fn MultiView(comptime n_includes: usize, comptime n_excludes: usize) type {
             pub fn init(view: *Self) Iterator {
                 const ptr = view.registry.components.get(view.type_ids[0]).?;
                 const internal_it = @intToPtr(*Storage(u8), ptr).set.reverseIterator();
-                return .{
-                    .view = view,
-                    .internal_it = internal_it
-                };
+                return .{ .view = view, .internal_it = internal_it };
             }
 
             pub fn next(it: *Iterator) ?Entity {
@@ -130,7 +127,7 @@ pub fn MultiView(comptime n_includes: usize, comptime n_excludes: usize) type {
         fn sort(self: *Self) void {
             // get our component counts in an array so we can sort the type_ids based on how many entities are in each
             var sub_items: [n_includes]usize = undefined;
-            for (self.type_ids) |tid, i| {
+            for (self.type_ids, 0..) |tid, i| {
                 const ptr = self.registry.components.get(tid).?;
                 const store = @intToPtr(*Storage(u8), ptr);
                 sub_items[i] = store.len();
@@ -201,7 +198,7 @@ test "single basic view data" {
 
     try std.testing.expectEqual(view.get(3).*, 30);
 
-    for (view.data()) |entity, i| {
+    for (view.data(), 0..) |entity, i| {
         if (i == 0)
             try std.testing.expectEqual(entity, 3);
         if (i == 1)
@@ -210,7 +207,7 @@ test "single basic view data" {
             try std.testing.expectEqual(entity, 7);
     }
 
-    for (view.raw()) |data, i| {
+    for (view.raw(), 0..) |data, i| {
         if (i == 0)
             try std.testing.expectEqual(data, 30);
         if (i == 1)

--- a/src/process/process.zig
+++ b/src/process/process.zig
@@ -6,10 +6,10 @@ pub const Process = struct {
     const State = enum(u8) { uninitialized, running, paused, succeeded, failed, aborted, finished };
 
     updateFn: *const fn (self: *Process) void,
-    startFn: ?*const fn  (self: *Process) void = null,
-    abortedFn: ?*const fn  (self: *Process) void = null,
-    failedFn: ?*const fn  (self: *Process) void = null,
-    succeededFn: ?*const fn  (self: *Process) void = null,
+    startFn: ?*const fn (self: *Process) void = null,
+    abortedFn: ?*const fn (self: *Process) void = null,
+    failedFn: ?*const fn (self: *Process) void = null,
+    succeededFn: ?*const fn (self: *Process) void = null,
     deinit: *const fn (self: *Process, allocator: std.mem.Allocator) void = undefined,
 
     state: State = .uninitialized,

--- a/src/signals/sink.zig
+++ b/src/signals/sink.zig
@@ -18,7 +18,7 @@ pub fn Sink(comptime Event: type) type {
             return Self{ .insert_index = owning_signal.calls.items.len };
         }
 
-        pub fn before(self: Self, callback: ?*const fn  (Event) void) Self {
+        pub fn before(self: Self, callback: ?*const fn (Event) void) Self {
             if (callback) |cb| {
                 if (self.indexOf(cb)) |index| {
                     return Self{ .insert_index = index };
@@ -59,7 +59,7 @@ pub fn Sink(comptime Event: type) type {
         }
 
         fn indexOf(_: Self, callback: *const fn (Event) void) ?usize {
-            for (owning_signal.calls.items) |call, i| {
+            for (owning_signal.calls.items, 0..) |call, i| {
                 if (call.containsFree(callback)) {
                     return i;
                 }
@@ -68,7 +68,7 @@ pub fn Sink(comptime Event: type) type {
         }
 
         fn indexOfBound(_: Self, ctx: anytype) ?usize {
-            for (owning_signal.calls.items) |call, i| {
+            for (owning_signal.calls.items, 0..) |call, i| {
                 if (call.containsBound(ctx)) {
                     return i;
                 }

--- a/tests/groups_test.zig
+++ b/tests/groups_test.zig
@@ -14,7 +14,7 @@ const Rotation = struct { x: f32 = 0 };
 
 fn printStore(store: anytype, name: []const u8) void {
     std.debug.print("--- {} ---\n", .{name});
-    for (store.set.dense.items) |e, i| {
+    for (store.set.dense.items, 0..) |e, i| {
         std.debug.print("e[{}] s[{}]{}", .{ e, store.set.page(store.set.dense.items[i]), store.set.sparse.items[store.set.page(store.set.dense.items[i])] });
         std.debug.print(" ({d:.2})   ", .{store.instances.items[i]});
     }


### PR DESCRIPTION
Zig format to add second argument in for loops for capturing index.

Change mutating for loops to loop over references.

Updated deprecated usages of std.mem.set and exe.run

Updated cache_root to assign Directory object

Updated hash string to remove comptime.

Remove boundFn as no longer exists, change Fn field from args to params.
