### PR TITLE
Use `addModule` instead of `createModule` for package visibility

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,7 +4,7 @@ const builtin = @import("builtin");
 
 pub fn build(b: *Builder) void {
     const optimize = b.standardOptimizeOption(.{});
-    const ecs_module = b.createModule(.{
+    const ecs_module = b.addModule("zig-ecs", .{
         .source_file = std.build.FileSource{ .path = "src/ecs.zig" },
     });
 


### PR DESCRIPTION
According to the [zig documentation](https://ziglang.org/documentation/master/std/#A;std:Build.addModule) the difference is that `addModule()` creates a module and adds it to the package's module set, making it available to other packages which depend on this one. `createModule()` can be used instead to create a private module.

Using `addModule` enables us to use zig-ecs in build.zig.zon

build.zig.zon:
``` zig
.{
    .name = "Foo",
    .version = "0.0.1",
    .dependencies = .{
        .zig_ecs = .{
            .url = "https://github.com/prime31/zig-ecs/archive/20e83efc681f85f6468ac6fdcb905ed28058288b.tar.gz",
            .hash = "12203176d35de3d948b68536f17c2aa16c7567a5dc91a67b69361b93633732b4f626",
        }
    }
}
```

build.zig:

``` zig
exe.addModule("ecs", b.dependency("zig_ecs", .{}).module("zig-ecs"));
```