### PR TITLE
Zig 0.11.0-dev.3735+a72d634b7 Changes + `@call` usage errors

### DIFF
--- a/src/ecs/groups.zig
+++ b/src/ecs/groups.zig
@@ -138,7 +138,7 @@ pub const OwningGroup = struct {
     /// grabs an untyped (u1) reference to the first Storage(T) in the owned array
     fn firstOwnedStorage(self: OwningGroup) *Storage(u1) {
         const ptr = self.registry.components.get(self.group_data.owned[0]).?;
-        return @intToPtr(*Storage(u1), ptr);
+        return @ptrFromInt(*Storage(u1), ptr);
     }
 
     /// total number of entities in the group
@@ -265,7 +265,7 @@ pub const OwningGroup = struct {
             // skip the first one since its what we are using to sort with
             for (self.group_data.owned[1..]) |type_id| {
                 var other_ptr = self.registry.components.get(type_id).?;
-                var storage = @intToPtr(*Storage(u1), other_ptr);
+                var storage = @ptrFromInt(*Storage(u1), other_ptr);
                 storage.swap(storage.data()[pos], entity);
             }
         }

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -553,7 +553,7 @@ pub const Registry = struct {
             // update super on all owned Storages to be the max of size and their current super value
             inline for (owned) |t| {
                 var storage = self.assure(t);
-                storage.super = std.math.max(storage.super, new_group_data.size);
+                storage.super = @max(storage.super, new_group_data.size);
             }
         }
 

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -632,7 +632,7 @@ pub const Registry = struct {
                 name.* = @typeName(types[i]);
             }
 
-            std.sort.block([]const u8, &names, {}, impl.asc);
+            std.sort.pdq([]const u8, &names, {}, impl.asc);
 
             comptime var res: []const u8 = "";
             inline for (names) |name| res = res ++ name;

--- a/src/ecs/utils.zig
+++ b/src/ecs/utils.zig
@@ -7,7 +7,7 @@ pub const ErasedPtr = struct {
         if (@sizeOf(@TypeOf(ptr)) == 0) {
             return .{ .ptr = undefined };
         }
-        return .{ .ptr = @ptrToInt(ptr) };
+        return .{ .ptr = @intFromPtr(ptr) };
     }
 
     pub fn as(self: ErasedPtr, comptime T: type) *T {
@@ -19,7 +19,7 @@ pub const ErasedPtr = struct {
     pub fn asPtr(self: ErasedPtr, comptime PtrT: type) PtrT {
         if (@sizeOf(PtrT) == 0)
             return @as(PtrT, undefined);
-        return @intToPtr(PtrT, self.ptr);
+        return @ptrFromInt(PtrT, self.ptr);
     }
 };
 

--- a/src/ecs/views.zig
+++ b/src/ecs/views.zig
@@ -68,7 +68,7 @@ pub fn MultiView(comptime n_includes: usize, comptime n_excludes: usize) type {
 
             pub fn init(view: *Self) Iterator {
                 const ptr = view.registry.components.get(view.type_ids[0]).?;
-                const internal_it = @intToPtr(*Storage(u8), ptr).set.reverseIterator();
+                const internal_it = @ptrFromInt(*Storage(u8), ptr).set.reverseIterator();
                 return .{ .view = view, .internal_it = internal_it };
             }
 
@@ -77,7 +77,7 @@ pub fn MultiView(comptime n_includes: usize, comptime n_excludes: usize) type {
                     // entity must be in all other Storages
                     for (it.view.type_ids) |tid| {
                         const ptr = it.view.registry.components.get(tid).?;
-                        if (!@intToPtr(*Storage(u1), ptr).contains(entity)) {
+                        if (!@ptrFromInt(*Storage(u1), ptr).contains(entity)) {
                             break :blk;
                         }
                     }
@@ -85,7 +85,7 @@ pub fn MultiView(comptime n_includes: usize, comptime n_excludes: usize) type {
                     // entity must not be in all other excluded Storages
                     for (it.view.exclude_type_ids) |tid| {
                         const ptr = it.view.registry.components.get(tid).?;
-                        if (@intToPtr(*Storage(u1), ptr).contains(entity)) {
+                        if (@ptrFromInt(*Storage(u1), ptr).contains(entity)) {
                             break :blk;
                         }
                     }
@@ -104,7 +104,7 @@ pub fn MultiView(comptime n_includes: usize, comptime n_excludes: usize) type {
 
             fn getInternalIteratorInstance(it: *Iterator) ReverseSliceIterator(Entity) {
                 const ptr = it.view.registry.components.get(it.view.type_ids[0]).?;
-                return @intToPtr(*Storage(u8), ptr).set.reverseIterator();
+                return @ptrFromInt(*Storage(u8), ptr).set.reverseIterator();
             }
         };
 
@@ -129,7 +129,7 @@ pub fn MultiView(comptime n_includes: usize, comptime n_excludes: usize) type {
             var sub_items: [n_includes]usize = undefined;
             for (self.type_ids, 0..) |tid, i| {
                 const ptr = self.registry.components.get(tid).?;
-                const store = @intToPtr(*Storage(u8), ptr);
+                const store = @ptrFromInt(*Storage(u8), ptr);
                 sub_items[i] = store.len();
             }
 

--- a/src/resources/assets.zig
+++ b/src/resources/assets.zig
@@ -17,7 +17,7 @@ pub const Assets = struct {
         var iter = self.caches.iterator();
         while (iter.next()) |ptr| {
             // HACK: we dont know the Type here but we need to call deinit
-            @intToPtr(*Cache(u1), ptr.value_ptr.*).deinit();
+            @ptrFromInt(*Cache(u1), ptr.value_ptr.*).deinit();
         }
 
         self.caches.deinit();
@@ -25,11 +25,11 @@ pub const Assets = struct {
 
     pub fn get(self: *Assets, comptime AssetT: type) *Cache(AssetT) {
         if (self.caches.get(utils.typeId(AssetT))) |tid| {
-            return @intToPtr(*Cache(AssetT), tid);
+            return @ptrFromInt(*Cache(AssetT), tid);
         }
 
         var cache = Cache(AssetT).initPtr(self.allocator);
-        _ = self.caches.put(utils.typeId(AssetT), @ptrToInt(cache)) catch unreachable;
+        _ = self.caches.put(utils.typeId(AssetT), @intFromPtr(cache)) catch unreachable;
         return cache;
     }
 

--- a/src/resources/cache.zig
+++ b/src/resources/cache.zig
@@ -59,7 +59,7 @@ pub fn Cache(comptime T: type) type {
         pub fn remove(self: *@This(), id: u32) void {
             if (self.resources.fetchRemove(id)) |kv| {
                 if (@hasDecl(T, "deinit")) {
-                    @call(.always_inline, @field(kv.value, "deinit"), .{});
+                    @call(.always_inline, T.deinit, .{kv.value});
                 }
             }
         }
@@ -69,7 +69,7 @@ pub fn Cache(comptime T: type) type {
             if (@hasDecl(T, "deinit")) {
                 var iter = self.resources.iterator();
                 while (iter.next()) |kv| {
-                    @call(.always_inline, @field(kv.value_ptr.*, "deinit"), .{});
+                    @call(.always_inline, T.deinit, .{kv.value_ptr.*});
                 }
             }
             self.resources.clearAndFree();

--- a/src/signals/delegate.zig
+++ b/src/signals/delegate.zig
@@ -17,12 +17,13 @@ pub fn Delegate(comptime Event: type) type {
             std.debug.assert(@intFromPtr(ctx) != 0);
 
             const T = @TypeOf(ctx);
+            const BaseT = @typeInfo(T).Pointer.child;
             return Self{
                 .ctx_ptr_address = @intFromPtr(ctx),
                 .callback = .{
                     .bound = struct {
                         fn cb(self: usize, param: Event) void {
-                            @call(.always_inline, @field(@ptrFromInt(T, self), fn_name), .{param});
+                            @call(.always_inline, @field(BaseT, fn_name), .{ @ptrFromInt(T, self), param });
                         }
                     }.cb,
                 },

--- a/src/signals/delegate.zig
+++ b/src/signals/delegate.zig
@@ -14,15 +14,15 @@ pub fn Delegate(comptime Event: type) type {
         /// sets a bound function as the Delegate callback
         pub fn initBound(ctx: anytype, comptime fn_name: []const u8) Self {
             std.debug.assert(@typeInfo(@TypeOf(ctx)) == .Pointer);
-            std.debug.assert(@ptrToInt(ctx) != 0);
+            std.debug.assert(@intFromPtr(ctx) != 0);
 
             const T = @TypeOf(ctx);
             return Self{
-                .ctx_ptr_address = @ptrToInt(ctx),
+                .ctx_ptr_address = @intFromPtr(ctx),
                 .callback = .{
                     .bound = struct {
                         fn cb(self: usize, param: Event) void {
-                            @call(.always_inline, @field(@intToPtr(T, self), fn_name), .{param});
+                            @call(.always_inline, @field(@ptrFromInt(T, self), fn_name), .{param});
                         }
                     }.cb,
                 },
@@ -51,11 +51,11 @@ pub fn Delegate(comptime Event: type) type {
         }
 
         pub fn containsBound(self: Self, ctx: anytype) bool {
-            std.debug.assert(@ptrToInt(ctx) != 0);
+            std.debug.assert(@intFromPtr(ctx) != 0);
             std.debug.assert(@typeInfo(@TypeOf(ctx)) == .Pointer);
 
             return switch (self.callback) {
-                .bound => @ptrToInt(ctx) == self.ctx_ptr_address,
+                .bound => @intFromPtr(ctx) == self.ctx_ptr_address,
                 else => false,
             };
         }

--- a/src/signals/dispatcher.zig
+++ b/src/signals/dispatcher.zig
@@ -18,7 +18,7 @@ pub const Dispatcher = struct {
         var iter = self.signals.iterator();
         while (iter.next()) |ptr| {
             // HACK: we dont know the Type here but we need to call deinit
-            var signal = @intToPtr(*Signal(void), ptr.value_ptr.*);
+            var signal = @ptrFromInt(*Signal(void), ptr.value_ptr.*);
             signal.deinit();
         }
 
@@ -28,11 +28,11 @@ pub const Dispatcher = struct {
     fn assure(self: *Dispatcher, comptime T: type) *Signal(T) {
         var type_id = utils.typeId(T);
         if (self.signals.get(type_id)) |value| {
-            return @intToPtr(*Signal(T), value);
+            return @ptrFromInt(*Signal(T), value);
         }
 
         var signal = Signal(T).create(self.allocator);
-        var signal_ptr = @ptrToInt(signal);
+        var signal_ptr = @intFromPtr(signal);
         _ = self.signals.put(type_id, signal_ptr) catch unreachable;
         return signal;
     }

--- a/tests/groups_test.zig
+++ b/tests/groups_test.zig
@@ -30,8 +30,8 @@ test "sort BasicGroup by Entity" {
     var i: usize = 0;
     while (i < 5) : (i += 1) {
         var e = reg.create();
-        reg.add(e, Sprite{ .x = @intToFloat(f32, i) });
-        reg.add(e, Renderable{ .x = @intToFloat(f32, i) });
+        reg.add(e, Sprite{ .x = @floatFromInt(f32, i) });
+        reg.add(e, Renderable{ .x = @floatFromInt(f32, i) });
     }
 
     const SortContext = struct {
@@ -64,8 +64,8 @@ test "sort BasicGroup by Component" {
     var i: usize = 0;
     while (i < 5) : (i += 1) {
         var e = reg.create();
-        reg.add(e, Sprite{ .x = @intToFloat(f32, i) });
-        reg.add(e, Renderable{ .x = @intToFloat(f32, i) });
+        reg.add(e, Sprite{ .x = @floatFromInt(f32, i) });
+        reg.add(e, Renderable{ .x = @floatFromInt(f32, i) });
     }
 
     const SortContext = struct {
@@ -92,8 +92,8 @@ test "sort OwningGroup by Entity" {
     var i: usize = 0;
     while (i < 5) : (i += 1) {
         var e = reg.create();
-        reg.add(e, Sprite{ .x = @intToFloat(f32, i) });
-        reg.add(e, Renderable{ .x = @intToFloat(f32, i) });
+        reg.add(e, Sprite{ .x = @floatFromInt(f32, i) });
+        reg.add(e, Renderable{ .x = @floatFromInt(f32, i) });
     }
 
     const SortContext = struct {
@@ -125,8 +125,8 @@ test "sort OwningGroup by Component" {
     var i: usize = 0;
     while (i < 5) : (i += 1) {
         var e = reg.create();
-        reg.add(e, Sprite{ .x = @intToFloat(f32, i) });
-        reg.add(e, Renderable{ .x = @intToFloat(f32, i) });
+        reg.add(e, Sprite{ .x = @floatFromInt(f32, i) });
+        reg.add(e, Renderable{ .x = @floatFromInt(f32, i) });
     }
 
     const SortContext = struct {
@@ -153,11 +153,11 @@ test "sort OwningGroup by Component ensure unsorted non-matches" {
     var i: usize = 0;
     while (i < 5) : (i += 1) {
         var e = reg.create();
-        reg.add(e, Sprite{ .x = @intToFloat(f32, i) });
-        reg.add(e, Renderable{ .x = @intToFloat(f32, i) });
+        reg.add(e, Sprite{ .x = @floatFromInt(f32, i) });
+        reg.add(e, Renderable{ .x = @floatFromInt(f32, i) });
 
         var e2 = reg.create();
-        reg.add(e2, Sprite{ .x = @intToFloat(f32, i + 1 * 50) });
+        reg.add(e2, Sprite{ .x = @floatFromInt(f32, i + 1 * 50) });
     }
 
     try std.testing.expectEqual(group.len(), 5);
@@ -223,8 +223,8 @@ test "nested OwningGroups entity order" {
     var i: usize = 0;
     while (i < 5) : (i += 1) {
         var e = reg.create();
-        reg.add(e, Sprite{ .x = @intToFloat(f32, i) });
-        reg.add(e, Renderable{ .x = @intToFloat(f32, i) });
+        reg.add(e, Sprite{ .x = @floatFromInt(f32, i) });
+        reg.add(e, Renderable{ .x = @floatFromInt(f32, i) });
     }
 
     try std.testing.expectEqual(group1.len(), 5);

--- a/tests/registry_test.zig
+++ b/tests/registry_test.zig
@@ -97,7 +97,7 @@ test "destroy" {
     var i = @as(u8, 0);
     while (i < 255) : (i += 1) {
         const e = reg.create();
-        reg.add(e, Position{ .x = @intToFloat(f32, i), .y = @intToFloat(f32, i) });
+        reg.add(e, Position{ .x = @floatFromInt(f32, i), .y = @floatFromInt(f32, i) });
     }
 
     reg.destroy(3);
@@ -106,7 +106,7 @@ test "destroy" {
     i = 0;
     while (i < 6) : (i += 1) {
         if (i != 3 and i != 4)
-            try std.testing.expectEqual(Position{ .x = @intToFloat(f32, i), .y = @intToFloat(f32, i) }, reg.getConst(Position, i));
+            try std.testing.expectEqual(Position{ .x = @floatFromInt(f32, i), .y = @floatFromInt(f32, i) }, reg.getConst(Position, i));
     }
 }
 

--- a/tests/registry_test.zig
+++ b/tests/registry_test.zig
@@ -58,7 +58,7 @@ test "context not pointer" {
     // reg.setContext(pos);
 }
 
-test "context get/set/unset" {
+test "context get/set/unset typed" {
     const SomeType = struct { dummy: u1 };
 
     var reg = Registry.init(std.testing.allocator);


### PR DESCRIPTION
The latest master version of Zig have some new way to cast. Instead of `@srcToDest` you use `@destFromSrc`.

``` zig
// If you want to cast a float to an int
const old = @floatToInt(i32, x);
const new = @intFromFloat(i32, x);
```

This PR also fixes the `@call` usage errors. Alot of techiques ~hacks~ are used, an example of this is:
``` zig
pub fn remove(self: *@This(), id: u32) void {
    if (self.resources.fetchRemove(id)) |kv| {
        if (@hasDecl(T, "deinit")) {
            @call(.always_inline, @field(kv.value, "deinit"), .{});    // OLD
            @call(.always_inline, T.deinit, .{kv.value});              // NEW
        }
    }
}
```

It also now use `@max` instead of `std.math.max()` and renamed a test so that it will not be duplicated

`std.sort.sort` is also deprecated. I don't know what to use so I choose `std.sort.block`