### PR TITLE
add `fetchRemove` and `fetchUpdate` to the registry

### DIFF
--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -322,6 +322,36 @@ pub const Registry = struct {
         }
     }
 
+    /// same as addOrReplace but it returns the previous value (if any)
+    pub fn fetchReplace(self: *Registry, entity: Entity, value: anytype) ?@TypeOf(value) {
+        assert(self.valid(entity));
+
+        const store = self.assure(@TypeOf(value));
+        if (store.tryGet(entity)) |found| {
+            var old = found.*;
+            found.* = value;
+            store.update.publish(entity);
+            return old;
+        } else {
+            store.add(entity, value);
+            return null;
+        }
+    }
+
+    /// same as remove but it returns the previous value (if any)
+    pub fn fetchRemove(self: *Registry, comptime T: type, entity: Entity) ?T {
+        assert(self.valid(entity));
+
+        const store = self.assure(T);
+        if (store.tryGet(entity)) |found| {
+            var old = found.*;
+            store.remove(entity);
+            return old;
+        } else {
+            return null;
+        }
+    }
+
     /// shortcut for add-or-replace raw comptime_int/float without having to @as cast
     pub fn addOrReplaceTyped(self: *Registry, comptime T: type, entity: Entity, value: T) void {
         self.addOrReplace(entity, value);

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -459,6 +459,11 @@ pub const Registry = struct {
         return MultiView(includes.len, excludes.len).init(self, includes_arr, excludes_arr);
     }
 
+    pub fn basicView(self: *Registry, comptime Component: anytype) BasicView(Component) {
+        // just one include so use the optimized BasicView
+        return BasicView(Component).init(self.assure(Component));
+    }
+
     /// returns the Type that a view will be based on the includes and excludes
     fn ViewType(comptime includes: anytype, comptime excludes: anytype) type {
         if (includes.len == 1 and excludes.len == 0) return BasicView(includes[0]);

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -215,7 +215,7 @@ pub const Registry = struct {
     }
 
     pub fn assure(self: *Registry, comptime T: type) *Storage(T) {
-        var type_id = utils.typeId(T);
+        const type_id = comptime utils.typeId(T);
         if (self.components.getEntry(type_id)) |kv| {
             return @as(*Storage(T), @ptrFromInt(kv.value_ptr.*));
         }

--- a/src/signals/sink.zig
+++ b/src/signals/sink.zig
@@ -36,11 +36,15 @@ pub fn Sink(comptime Event: type) type {
             return self;
         }
 
+        /// connects a callback `fn(Event) void` to this sink
+        /// NOTE: each callback can only be connected ONCE to the same sink
         pub fn connect(self: Self, callback: *const fn (Event) void) void {
             std.debug.assert(self.indexOf(callback) == null);
             _ = owning_signal.calls.insert(self.insert_index, Delegate(Event).initFree(callback)) catch unreachable;
         }
 
+        /// connects a context `fn ctx.fn_name(Event) void` to this sink
+        /// NOTE: each context can only be connected ONCE to the same sink
         pub fn connectBound(self: Self, ctx: anytype, comptime fn_name: []const u8) void {
             std.debug.assert(self.indexOfBound(ctx) == null);
             _ = owning_signal.calls.insert(self.insert_index, Delegate(Event).initBound(ctx, fn_name)) catch unreachable;


### PR DESCRIPTION
useful when a component requires deinit.

```zig

if (registry.fetchUpdate(entity, new_value)) |prev_value| {
    prev_value.deinit();
}

```