### PR TITLE
add type checks to prevent adding pointers as components

### DIFF
--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -334,7 +334,7 @@ pub const Registry = struct {
     }
 
     /// emits a signal for the onUpdate sink
-    pub fn signalUpdated(self: *Registry, comptime T: type, entity: Entity) void {
+    pub fn notifyUpdated(self: *Registry, comptime T: type, entity: Entity) void {
         assert(self.valid(entity));
 
         const store = self.assure(T);

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -532,7 +532,7 @@ pub const Registry = struct {
         std.debug.assert(@typeInfo(@TypeOf(includes)) == .Struct);
         std.debug.assert(@typeInfo(@TypeOf(excludes)) == .Struct);
         std.debug.assert(owned.len + includes.len > 0);
-        std.debug.assert(owned.len + includes.len + excludes.len > 1);
+        std.debug.assert(owned.len + includes.len + excludes.len >= 1);
 
         // create a unique hash to identify the group so that we can look it up
         const hash = comptime hashGroupTypes(owned, includes, excludes);

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -421,6 +421,16 @@ pub const Registry = struct {
         return self.assure(T).tryGet(entity);
     }
 
+    /// same as tryGet but it stores the result on the stack, this option tends to be preferrable when dealing
+    /// with complex logic that may create CPU cache misses
+    pub fn tryGetConst(self: *Registry, comptime T: type, entity: Entity) ?T {
+        if (self.assure(T).tryGet(entity)) |ptr| {
+            var ret: T = ptr.*;
+            return ret;
+        }
+        return null;
+    }
+
     /// Returns a Sink object for the given component to add/remove listeners with
     pub fn onConstruct(self: *Registry, comptime T: type) Sink(Entity) {
         return self.assure(T).onConstruct();

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -333,6 +333,16 @@ pub const Registry = struct {
         }
     }
 
+    /// emits a signal for the onUpdate sink
+    pub fn signalUpdated(self: *Registry, comptime T: type, entity: Entity) void {
+        assert(self.valid(entity));
+
+        const store = self.assure(T);
+        if (store.contains(entity)) {
+            store.update.publish(entity);
+        }
+    }
+
     /// same as addOrReplace but it returns the previous value (if any)
     pub fn fetchReplace(self: *Registry, entity: Entity, value: anytype) ?@TypeOf(value) {
         assert(self.valid(entity));

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -494,6 +494,11 @@ pub const Registry = struct {
         return BasicView(Component).init(self.assure(Component));
     }
 
+    pub fn entityIterator(self: *Registry, comptime Component: anytype) utils.ReverseSliceIterator(Entity) {
+        // just one include so use the optimized BasicView
+        return BasicView(Component).init(self.assure(Component)).entityIterator();
+    }
+
     /// returns the Type that a view will be based on the includes and excludes
     fn ViewType(comptime includes: anytype, comptime excludes: anytype) type {
         if (includes.len == 1 and excludes.len == 0) return BasicView(includes[0]);

--- a/src/ecs/utils.zig
+++ b/src/ecs/utils.zig
@@ -48,6 +48,31 @@ pub fn ReverseSliceIterator(comptime T: type) type {
     };
 }
 
+pub fn ReverseSlicePointerIterator(comptime T: type) type {
+    return struct {
+        slice: []T,
+        index: usize,
+
+        pub fn init(slice: []T) @This() {
+            return .{
+                .slice = slice,
+                .index = slice.len,
+            };
+        }
+
+        pub fn next(self: *@This()) ?*T {
+            if (self.index == 0) return null;
+            self.index -= 1;
+
+            return &self.slice[self.index];
+        }
+
+        pub fn reset(self: *@This()) void {
+            self.index = self.slice.len;
+        }
+    };
+}
+
 /// sorts items using lessThan and keeps sub_items with the same sort
 pub fn sortSub(comptime T1: type, comptime T2: type, items: []T1, sub_items: []T2, comptime lessThan: *const fn (void, lhs: T1, rhs: T1) bool) void {
     var i: usize = 1;

--- a/src/ecs/views.zig
+++ b/src/ecs/views.zig
@@ -227,7 +227,7 @@ test "basic multi view" {
     var e1 = reg.create();
     var e2 = reg.create();
 
-    reg.add(e0, @as(i32, -0));
+    reg.add(e0, @as(i32, 0));
     reg.add(e1, @as(i32, -1));
     reg.add(e2, @as(i32, -2));
 
@@ -264,7 +264,7 @@ test "basic multi view with excludes" {
     var e1 = reg.create();
     var e2 = reg.create();
 
-    reg.add(e0, @as(i32, -0));
+    reg.add(e0, @as(i32, 0));
     reg.add(e1, @as(i32, -1));
     reg.add(e2, @as(i32, -2));
 

--- a/src/ecs/views.zig
+++ b/src/ecs/views.zig
@@ -48,6 +48,10 @@ pub fn BasicView(comptime T: type) type {
             return utils.ReverseSliceIterator(T).init(self.storage.instances.items);
         }
 
+        pub fn mutIterator(self: Self) utils.ReverseSlicePointerIterator(T) {
+            return utils.ReverseSlicePointerIterator(T).init(self.storage.instances.items);
+        }
+
         pub fn entityIterator(self: Self) utils.ReverseSliceIterator(Entity) {
             return self.storage.set.reverseIterator();
         }


### PR DESCRIPTION
- add type checks to prevent adding pointers as components
- also adds `notifyUpdated(Component, entity)` which is used to notify all observers about an updated component (maybe by pointer). Has the same effect as this, but with way fewer operations
   ```zig
   fn notifyUpdated(Component: type, entity: Entity) void {
       if (registry.tryGet(Component, entity)) |value| {
           registry.addOrReplace(entity, value.*);
       }
   }
   ```
- fixes groups and tests for newest zig version