### PR TITLE
Update to Zig 0.12.0-dev.1830+779b8e259 (latest Dec 17 2023)

### DIFF
--- a/examples/group_sort.zig
+++ b/examples/group_sort.zig
@@ -24,12 +24,12 @@ fn createEntities(reg: *ecs.Registry) void {
     var timer = std.time.Timer.start() catch unreachable;
     var i: usize = 0;
     while (i < total_entities) : (i += 1) {
-        var e1 = reg.create();
+        const e1 = reg.create();
         reg.add(e1, Position{ .x = 1, .y = r.random().float(f32) * 100 });
         reg.add(e1, Velocity{ .x = 1, .y = r.random().float(f32) * 100 });
     }
 
-    var end = timer.lap();
+    const end = timer.lap();
     std.debug.print("create {d} entities: {d}\n", .{ total_entities, @as(f64, @floatFromInt(end)) / 1000000000 });
 }
 

--- a/examples/simple.zig
+++ b/examples/simple.zig
@@ -11,11 +11,11 @@ pub fn main() !void {
     var reg = ecs.Registry.init(std.heap.c_allocator);
     defer reg.deinit();
 
-    var e1 = reg.create();
+    const e1 = reg.create();
     reg.add(e1, Position{ .x = 0, .y = 0 });
     reg.add(e1, Velocity{ .x = 5, .y = 7 });
 
-    var e2 = reg.create();
+    const e2 = reg.create();
     reg.add(e2, Position{ .x = 10, .y = 10 });
     reg.add(e2, Velocity{ .x = 15, .y = 17 });
 
@@ -23,7 +23,7 @@ pub fn main() !void {
 
     var iter = view.entityIterator();
     while (iter.next()) |entity| {
-        var pos = view.get(Position, entity);
+        const pos = view.get(Position, entity);
         const vel = view.getConst(Velocity, entity);
         std.debug.print(
             "entity: {}, pos: (x = {d}, y = {d}), vel: (x = {d}, y = {d})\n",

--- a/examples/view_vs_group.zig
+++ b/examples/view_vs_group.zig
@@ -24,12 +24,12 @@ fn createEntities(reg: *ecs.Registry) void {
     var timer = std.time.Timer.start() catch unreachable;
     var i: usize = 0;
     while (i < 1000000) : (i += 1) {
-        var e1 = reg.create();
+        const e1 = reg.create();
         reg.add(e1, Position{ .x = 1, .y = 1 });
         reg.add(e1, Velocity{ .x = 1, .y = 1 });
     }
 
-    var end = timer.lap();
+    const end = timer.lap();
     std.debug.print("create entities: \t{d}\n", .{@as(f64, @floatFromInt(end)) / 1000000000});
 }
 
@@ -40,14 +40,14 @@ fn iterateView(reg: *ecs.Registry) void {
     var timer = std.time.Timer.start() catch unreachable;
     var iter = view.entityIterator();
     while (iter.next()) |entity| {
-        var pos = view.get(Position, entity);
+        const pos = view.get(Position, entity);
         const vel = view.getConst(Velocity, entity);
 
         pos.*.x += vel.x;
         pos.*.y += vel.y;
     }
 
-    var end = timer.lap();
+    const end = timer.lap();
     std.debug.print("view (iter): \t{d}\n", .{@as(f64, @floatFromInt(end)) / 1000000000});
 }
 
@@ -61,7 +61,7 @@ fn nonOwningGroup(reg: *ecs.Registry) void {
     timer.reset();
     var group_iter = group.iterator();
     while (group_iter.next()) |entity| {
-        var pos = group.get(Position, entity);
+        const pos = group.get(Position, entity);
         const vel = group.getConst(Velocity, entity);
 
         pos.*.x += vel.x;

--- a/src/ecs/actor.zig
+++ b/src/ecs/actor.zig
@@ -77,8 +77,8 @@ test "actor structs" {
     actor.add(Velocity{ .x = 5, .y = 10 });
     actor.add(Position{});
 
-    var vel = actor.get(Velocity);
-    var pos = actor.get(Position);
+    const vel = actor.get(Velocity);
+    const pos = actor.get(Position);
 
     pos.*.x += vel.x;
     pos.*.y += vel.y;

--- a/src/ecs/component_storage.zig
+++ b/src/ecs/component_storage.zig
@@ -300,7 +300,7 @@ test "add/try-get/remove/clear" {
 
     store.remove(3);
 
-    var val_null = store.tryGet(3);
+    const val_null = store.tryGet(3);
     try std.testing.expectEqual(val_null, null);
 
     store.clear();

--- a/src/ecs/component_storage.zig
+++ b/src/ecs/component_storage.zig
@@ -16,7 +16,7 @@ pub fn ComponentStorage(comptime Component: type, comptime Entity: type) type {
     // non-zero sized type. That will make is_empty_struct false in deinit always so we can't use it. Instead, we stick
     // a small dummy struct in the instances ArrayList so it can safely be deallocated.
     // Perhaps we should just allocate instances with a dummy allocator or the tmp allocator?
-    comptime var ComponentOrDummy = if (is_empty_struct) struct { dummy: u1 } else Component;
+    const ComponentOrDummy = if (is_empty_struct) struct { dummy: u1 } else Component;
 
     return struct {
         const Self = @This();

--- a/src/ecs/entity.zig
+++ b/src/ecs/entity.zig
@@ -14,9 +14,9 @@ pub fn EntityTraitsType(comptime size: EntityTraitsSize) type {
 }
 
 fn EntityTraitsDefinition(comptime EntityType: type, comptime IndexType: type, comptime VersionType: type) type {
-    std.debug.assert(std.meta.trait.isUnsignedInt(EntityType));
-    std.debug.assert(std.meta.trait.isUnsignedInt(IndexType));
-    std.debug.assert(std.meta.trait.isUnsignedInt(VersionType));
+    std.debug.assert(@typeInfo(EntityType) == .Int and std.meta.Int(.unsigned, @bitSizeOf(EntityType)) == EntityType);
+    std.debug.assert(@typeInfo(IndexType) == .Int and std.meta.Int(.unsigned, @bitSizeOf(IndexType)) == IndexType);
+    std.debug.assert(@typeInfo(VersionType) == .Int and std.meta.Int(.unsigned, @bitSizeOf(VersionType)) == VersionType);
 
     const sizeOfIndexType = @bitSizeOf(IndexType);
     const sizeOfVersionType = @bitSizeOf(VersionType);

--- a/src/ecs/groups.zig
+++ b/src/ecs/groups.zig
@@ -59,7 +59,7 @@ pub const BasicGroup = struct {
                     return this.lessThan(this.wrapped_context, real_a, real_b);
                 }
             };
-            var wrapper = SortContext{ .group = self, .wrapped_context = context, .lessThan = lessThan };
+            const wrapper = SortContext{ .group = self, .wrapped_context = context, .lessThan = lessThan };
             self.group_data.entity_set.sort(wrapper, SortContext.sort);
         }
     }
@@ -264,7 +264,7 @@ pub const OwningGroup = struct {
 
             // skip the first one since its what we are using to sort with
             for (self.group_data.owned[1..]) |type_id| {
-                var other_ptr = self.registry.components.get(type_id).?;
+                const other_ptr = self.registry.components.get(type_id).?;
                 var storage = @as(*Storage(u1), @ptrFromInt(other_ptr));
                 storage.swap(storage.data()[pos], entity);
             }
@@ -279,7 +279,7 @@ test "BasicGroup creation/iteration" {
     var group = reg.group(.{}, .{ i32, u32 }, .{});
     try std.testing.expectEqual(group.len(), 0);
 
-    var e0 = reg.create();
+    const e0 = reg.create();
     reg.add(e0, @as(i32, 44));
     reg.add(e0, @as(u32, 55));
 
@@ -309,7 +309,7 @@ test "BasicGroup excludes" {
     var group = reg.group(.{}, .{i32}, .{u32});
     try std.testing.expectEqual(group.len(), 0);
 
-    var e0 = reg.create();
+    const e0 = reg.create();
     reg.add(e0, @as(i32, 44));
 
     std.debug.assert(group.len() == 1);
@@ -329,7 +329,7 @@ test "BasicGroup create late" {
     var reg = Registry.init(std.testing.allocator);
     defer reg.deinit();
 
-    var e0 = reg.create();
+    const e0 = reg.create();
     reg.add(e0, @as(i32, 44));
     reg.add(e0, @as(u32, 55));
 
@@ -343,7 +343,7 @@ test "OwningGroup" {
 
     var group = reg.group(.{ i32, u32 }, .{}, .{});
 
-    var e0 = reg.create();
+    const e0 = reg.create();
     reg.add(e0, @as(i32, 44));
     reg.add(e0, @as(u32, 55));
     try std.testing.expectEqual(group.len(), 1);
@@ -352,12 +352,12 @@ test "OwningGroup" {
     try std.testing.expectEqual(group.get(i32, e0).*, 44);
     try std.testing.expectEqual(group.getConst(u32, e0), 55);
 
-    var vals = group.getOwned(e0, struct { int: *i32, uint: *u32 });
+    const vals = group.getOwned(e0, struct { int: *i32, uint: *u32 });
     try std.testing.expectEqual(vals.int.*, 44);
     try std.testing.expectEqual(vals.uint.*, 55);
 
     vals.int.* = 666;
-    var vals2 = group.getOwned(e0, struct { int: *i32, uint: *u32 });
+    const vals2 = group.getOwned(e0, struct { int: *i32, uint: *u32 });
     try std.testing.expectEqual(vals2.int.*, 666);
 }
 
@@ -367,7 +367,7 @@ test "OwningGroup add/remove" {
 
     var group = reg.group(.{ i32, u32 }, .{}, .{});
 
-    var e0 = reg.create();
+    const e0 = reg.create();
     reg.add(e0, @as(i32, 44));
     reg.add(e0, @as(u32, 55));
     try std.testing.expectEqual(group.len(), 1);
@@ -380,12 +380,12 @@ test "OwningGroup iterate" {
     var reg = Registry.init(std.testing.allocator);
     defer reg.deinit();
 
-    var e0 = reg.create();
+    const e0 = reg.create();
     reg.add(e0, @as(i32, 44));
     reg.add(e0, @as(u32, 55));
     reg.add(e0, @as(u8, 11));
 
-    var e1 = reg.create();
+    const e1 = reg.create();
     reg.add(e1, @as(i32, 666));
     reg.add(e1, @as(u32, 999));
     reg.add(e1, @as(f32, 55.5));
@@ -417,7 +417,7 @@ test "OwningGroup each" {
     var reg = Registry.init(std.testing.allocator);
     defer reg.deinit();
 
-    var e0 = reg.create();
+    const e0 = reg.create();
     reg.add(e0, @as(i32, 44));
     reg.add(e0, @as(u32, 55));
 
@@ -430,9 +430,9 @@ test "OwningGroup each" {
             std.testing.expectEqual(components.uint.*, 55) catch unreachable;
         }
     };
-    var thing = Thing{};
+    const thing = Thing{};
 
-    var group = reg.group(.{ i32, u32 }, .{}, .{});
+    const group = reg.group(.{ i32, u32 }, .{}, .{});
     // group.each(thing.each); // zig v0.10.0: error: no field named 'each' in struct 'ecs.groups.test.OwningGroup each.Thing'
     _ = thing;
     // group.each(each); // zig v0.10.0: error: expected type 'ecs.groups.each__struct_6297', found 'ecs.groups.each__struct_3365'

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -708,7 +708,7 @@ pub const Registry = struct {
             std.sort.pdq([]const u8, &names, {}, impl.asc);
 
             comptime var res: []const u8 = "";
-            inline for (names) |name| res = res ++ name;
+            for (names) |name| res = res ++ name;
             return res;
         }
     }

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -224,8 +224,8 @@ pub const Registry = struct {
             return @as(*Storage(T), @ptrFromInt(kv.value_ptr.*));
         }
 
-        var comp_set = Storage(T).initPtr(self.allocator);
-        var comp_set_ptr = @intFromPtr(comp_set);
+        const comp_set = Storage(T).initPtr(self.allocator);
+        const comp_set_ptr = @intFromPtr(comp_set);
         _ = self.components.put(type_id, comp_set_ptr) catch unreachable;
         return comp_set;
     }
@@ -349,7 +349,7 @@ pub const Registry = struct {
 
         const store = self.assure(@TypeOf(value));
         if (store.tryGet(entity)) |found| {
-            var old = found.*;
+            const old = found.*;
             found.* = value;
             store.update.publish(entity);
             return old;
@@ -365,7 +365,7 @@ pub const Registry = struct {
 
         const store = self.assure(T);
         if (store.tryGet(entity)) |found| {
-            var old = found.*;
+            const old = found.*;
             store.remove(entity);
             return old;
         } else {
@@ -435,7 +435,7 @@ pub const Registry = struct {
     /// with complex logic that may create CPU cache misses
     pub fn tryGetConst(self: *Registry, comptime T: type, entity: Entity) ?T {
         if (self.assure(T).tryGet(entity)) |ptr| {
-            var ret: T = ptr.*;
+            const ret: T = ptr.*;
             return ret;
         }
         return null;
@@ -460,7 +460,7 @@ pub const Registry = struct {
     pub fn setContext(self: *Registry, context: anytype) void {
         std.debug.assert(@typeInfo(@TypeOf(context)) == .Pointer);
 
-        var type_id = utils.typeId(@typeInfo(@TypeOf(context)).Pointer.child);
+        const type_id = utils.typeId(@typeInfo(@TypeOf(context)).Pointer.child);
         _ = self.contexts.put(type_id, @intFromPtr(context)) catch unreachable;
     }
 

--- a/src/ecs/sparse_set.zig
+++ b/src/ecs/sparse_set.zig
@@ -89,7 +89,7 @@ pub fn SparseSet(comptime SparseT: type) type {
             }
 
             if (self.sparse.items[pos] == null) {
-                var new_page = self.sparse.allocator.alloc(SparseT, page_size) catch unreachable;
+                const new_page = self.sparse.allocator.alloc(SparseT, page_size) catch unreachable;
                 @memset(new_page, std.math.maxInt(SparseT));
                 self.sparse.items[pos] = new_page;
             }
@@ -163,8 +163,8 @@ pub fn SparseSet(comptime SparseT: type) type {
 
         /// Swaps two entities in the internal packed and sparse arrays
         pub fn swap(self: *Self, lhs: SparseT, rhs: SparseT) void {
-            var from = &self.sparse.items[self.page(lhs)].?[self.offset(lhs)];
-            var to = &self.sparse.items[self.page(rhs)].?[self.offset(rhs)];
+            const from = &self.sparse.items[self.page(lhs)].?[self.offset(lhs)];
+            const to = &self.sparse.items[self.page(rhs)].?[self.offset(rhs)];
 
             std.mem.swap(SparseT, &self.dense.items[from.*], &self.dense.items[to.*]);
             std.mem.swap(SparseT, from, to);
@@ -296,7 +296,7 @@ test "data() synced" {
     set.add(2);
     set.add(3);
 
-    var data = set.data();
+    const data = set.data();
     try std.testing.expectEqual(data[1], 1);
     try std.testing.expectEqual(set.len(), data.len);
 

--- a/src/ecs/type_store.zig
+++ b/src/ecs/type_store.zig
@@ -23,7 +23,7 @@ pub const TypeStore = struct {
 
     /// adds instance, returning a pointer to the item as it lives in the store
     pub fn add(self: *TypeStore, instance: anytype) void {
-        var bytes = self.allocator.alloc(u8, @sizeOf(@TypeOf(instance))) catch unreachable;
+        const bytes = self.allocator.alloc(u8, @sizeOf(@TypeOf(instance))) catch unreachable;
         std.mem.copy(u8, bytes, std.mem.asBytes(&instance));
         _ = self.map.put(utils.typeId(@TypeOf(instance)), bytes) catch unreachable;
     }
@@ -41,7 +41,7 @@ pub const TypeStore = struct {
 
     pub fn getOrAdd(self: *TypeStore, comptime T: type) *T {
         if (!self.has(T)) {
-            var instance = std.mem.zeroes(T);
+            const instance = std.mem.zeroes(T);
             self.add(instance);
         }
         return self.get(T);
@@ -65,22 +65,22 @@ test "TypeStore" {
     var store = TypeStore.init(std.testing.allocator);
     defer store.deinit();
 
-    var orig = Vector{ .x = 5, .y = 6, .z = 8 };
+    const orig = Vector{ .x = 5, .y = 6, .z = 8 };
     store.add(orig);
     try std.testing.expect(store.has(Vector));
     try std.testing.expectEqual(store.get(Vector).*, orig);
 
-    var v = store.get(Vector);
+    const v = store.get(Vector);
     try std.testing.expectEqual(v.*, Vector{ .x = 5, .y = 6, .z = 8 });
     v.*.x = 666;
 
-    var v2 = store.get(Vector);
+    const v2 = store.get(Vector);
     try std.testing.expectEqual(v2.*, Vector{ .x = 666, .y = 6, .z = 8 });
 
     store.remove(Vector);
     try std.testing.expect(!store.has(Vector));
 
-    var v3 = store.getOrAdd(u32);
+    const v3 = store.getOrAdd(u32);
     try std.testing.expectEqual(v3.*, 0);
     v3.* = 777;
 

--- a/src/ecs/type_store.zig
+++ b/src/ecs/type_store.zig
@@ -24,7 +24,7 @@ pub const TypeStore = struct {
     /// adds instance, returning a pointer to the item as it lives in the store
     pub fn add(self: *TypeStore, instance: anytype) void {
         const bytes = self.allocator.alloc(u8, @sizeOf(@TypeOf(instance))) catch unreachable;
-        std.mem.copy(u8, bytes, std.mem.asBytes(&instance));
+        @memcpy(bytes, std.mem.asBytes(&instance));
         _ = self.map.put(utils.typeId(@TypeOf(instance)), bytes) catch unreachable;
     }
 

--- a/src/ecs/utils.zig
+++ b/src/ecs/utils.zig
@@ -148,7 +148,7 @@ pub fn isComptime(comptime T: type) bool {
 }
 
 test "ReverseSliceIterator" {
-    var slice = std.testing.allocator.alloc(usize, 10) catch unreachable;
+    const slice = std.testing.allocator.alloc(usize, 10) catch unreachable;
     defer std.testing.allocator.free(slice);
 
     for (slice, 0..) |*item, i| {

--- a/src/ecs/views.zig
+++ b/src/ecs/views.zig
@@ -227,9 +227,9 @@ test "basic multi view" {
     var reg = Registry.init(std.testing.allocator);
     defer reg.deinit();
 
-    var e0 = reg.create();
-    var e1 = reg.create();
-    var e2 = reg.create();
+    const e0 = reg.create();
+    const e1 = reg.create();
+    const e2 = reg.create();
 
     reg.add(e0, @as(i32, 0));
     reg.add(e1, @as(i32, -1));
@@ -264,9 +264,9 @@ test "basic multi view with excludes" {
     var reg = Registry.init(std.testing.allocator);
     defer reg.deinit();
 
-    var e0 = reg.create();
-    var e1 = reg.create();
-    var e2 = reg.create();
+    const e0 = reg.create();
+    const e1 = reg.create();
+    const e2 = reg.create();
 
     reg.add(e0, @as(i32, 0));
     reg.add(e1, @as(i32, -1));

--- a/src/resources/assets.zig
+++ b/src/resources/assets.zig
@@ -28,7 +28,7 @@ pub const Assets = struct {
             return @as(*Cache(AssetT), @ptrFromInt(tid));
         }
 
-        var cache = Cache(AssetT).initPtr(self.allocator);
+        const cache = Cache(AssetT).initPtr(self.allocator);
         _ = self.caches.put(utils.typeId(AssetT), @intFromPtr(cache)) catch unreachable;
         return cache;
     }
@@ -38,7 +38,7 @@ pub const Assets = struct {
     }
 
     fn ReturnType(comptime loader: anytype, comptime strip_ptr: bool) type {
-        var ret = @typeInfo(@typeInfo(@TypeOf(@field(loader, "load"))).Pointer.child).Fn.return_type.?;
+        const ret = @typeInfo(@typeInfo(@TypeOf(@field(loader, "load"))).Pointer.child).Fn.return_type.?;
         if (strip_ptr) {
             return std.meta.Child(ret);
         }

--- a/src/resources/cache.zig
+++ b/src/resources/cache.zig
@@ -47,7 +47,7 @@ pub fn Cache(comptime T: type) type {
                 return resource;
             }
 
-            var resource = loader.load(loader);
+            const resource = loader.load(loader);
             _ = self.resources.put(id, resource) catch unreachable;
             return resource;
         }

--- a/src/signals/dispatcher.zig
+++ b/src/signals/dispatcher.zig
@@ -26,13 +26,13 @@ pub const Dispatcher = struct {
     }
 
     fn assure(self: *Dispatcher, comptime T: type) *Signal(T) {
-        var type_id = utils.typeId(T);
+        const type_id = utils.typeId(T);
         if (self.signals.get(type_id)) |value| {
             return @as(*Signal(T), @ptrFromInt(value));
         }
 
-        var signal = Signal(T).create(self.allocator);
-        var signal_ptr = @intFromPtr(signal);
+        const signal = Signal(T).create(self.allocator);
+        const signal_ptr = @intFromPtr(signal);
         _ = self.signals.put(type_id, signal_ptr) catch unreachable;
         return signal;
     }

--- a/tests/groups_test.zig
+++ b/tests/groups_test.zig
@@ -29,7 +29,7 @@ test "sort BasicGroup by Entity" {
 
     var i: usize = 0;
     while (i < 5) : (i += 1) {
-        var e = reg.create();
+        const e = reg.create();
         reg.add(e, Sprite{ .x = @as(f32, @floatFromInt(i)) });
         reg.add(e, Renderable{ .x = @as(f32, @floatFromInt(i)) });
     }
@@ -63,7 +63,7 @@ test "sort BasicGroup by Component" {
 
     var i: usize = 0;
     while (i < 5) : (i += 1) {
-        var e = reg.create();
+        const e = reg.create();
         reg.add(e, Sprite{ .x = @as(f32, @floatFromInt(i)) });
         reg.add(e, Renderable{ .x = @as(f32, @floatFromInt(i)) });
     }
@@ -91,7 +91,7 @@ test "sort OwningGroup by Entity" {
 
     var i: usize = 0;
     while (i < 5) : (i += 1) {
-        var e = reg.create();
+        const e = reg.create();
         reg.add(e, Sprite{ .x = @as(f32, @floatFromInt(i)) });
         reg.add(e, Renderable{ .x = @as(f32, @floatFromInt(i)) });
     }
@@ -124,7 +124,7 @@ test "sort OwningGroup by Component" {
 
     var i: usize = 0;
     while (i < 5) : (i += 1) {
-        var e = reg.create();
+        const e = reg.create();
         reg.add(e, Sprite{ .x = @as(f32, @floatFromInt(i)) });
         reg.add(e, Renderable{ .x = @as(f32, @floatFromInt(i)) });
     }
@@ -152,11 +152,11 @@ test "sort OwningGroup by Component ensure unsorted non-matches" {
 
     var i: usize = 0;
     while (i < 5) : (i += 1) {
-        var e = reg.create();
+        const e = reg.create();
         reg.add(e, Sprite{ .x = @as(f32, @floatFromInt(i)) });
         reg.add(e, Renderable{ .x = @as(f32, @floatFromInt(i)) });
 
-        var e2 = reg.create();
+        const e2 = reg.create();
         reg.add(e2, Sprite{ .x = @as(f32, @floatFromInt(i + 1 * 50)) });
     }
 
@@ -198,7 +198,7 @@ test "nested OwningGroups add/remove components" {
     try std.testing.expect(!reg.sortable(Transform));
     try std.testing.expect(reg.sortable(Renderable));
 
-    var e1 = reg.create();
+    const e1 = reg.create();
     reg.addTypes(e1, .{ Sprite, Renderable, Rotation });
     try std.testing.expectEqual(group1.len(), 1);
     try std.testing.expectEqual(group2.len(), 0);
@@ -222,7 +222,7 @@ test "nested OwningGroups entity order" {
 
     var i: usize = 0;
     while (i < 5) : (i += 1) {
-        var e = reg.create();
+        const e = reg.create();
         reg.add(e, Sprite{ .x = @as(f32, @floatFromInt(i)) });
         reg.add(e, Renderable{ .x = @as(f32, @floatFromInt(i)) });
     }

--- a/tests/registry_test.zig
+++ b/tests/registry_test.zig
@@ -15,7 +15,7 @@ test "Registry" {
     var reg = Registry.init(std.testing.allocator);
     defer reg.deinit();
 
-    var e1 = reg.create();
+    const e1 = reg.create();
 
     reg.addTypes(e1, .{ Empty, Position });
     reg.add(e1, BigOne{ .pos = Position{ .x = 5, .y = 5 }, .vel = Velocity{ .x = 5, .y = 5 }, .accel = Velocity{ .x = 5, .y = 5 } });
@@ -53,7 +53,7 @@ test "context not pointer" {
     var reg = Registry.init(std.testing.allocator);
     defer reg.deinit();
 
-    var pos = Position{ .x = 5, .y = 5 };
+    const pos = Position{ .x = 5, .y = 5 };
     _ = pos;
     // reg.setContext(pos);
 }
@@ -81,7 +81,7 @@ test "singletons" {
     var reg = Registry.init(std.testing.allocator);
     defer reg.deinit();
 
-    var pos = Position{ .x = 5, .y = 5 };
+    const pos = Position{ .x = 5, .y = 5 };
     reg.singletons().add(pos);
     try std.testing.expect(reg.singletons().has(Position));
     try std.testing.expectEqual(reg.singletons().get(Position).*, pos);
@@ -114,7 +114,7 @@ test "remove all" {
     var reg = Registry.init(std.testing.allocator);
     defer reg.deinit();
 
-    var e = reg.create();
+    const e = reg.create();
     reg.add(e, Position{ .x = 1, .y = 1 });
     reg.addTyped(u32, e, 666);
 


### PR DESCRIPTION
The latest master version of zig now enforces `var` to `const` if a value is never mutated with `var` keyword.

```zig
    var olde1 = reg.create();
    // Now becomes
    const e1 = reg.create();

    comptime var oldComponentOrDummy = = if (is_empty_struct) struct { dummy: u1 } else Component;
    // Now becomes
    const ComponentOrDummy = if (is_empty_struct) struct { dummy: u1 } else Component;
```

Also in the latest version of zig inline is noted redundant for `comptime` variables. So, no need to denote inline

```zig
    comptime var res: []const u8 = "";
    inline for (names) res = res ++name;
    // Now becomes
    for (names) |name| res = res ++name;
```

`std.mem.copy()` seems to have been removed. The standard now appears to be `@memcpy`

```zig
    var bytes = self.allocator.alloc(u8, @sizeOf(@TypeOf(instance))) catch unreachable;
    std.mem.copy(u8, bytes, std.mem.asBytes(&instance));
    // Now becomes
    @memcpy(bytes, std.mem.asBytes(&instance));
```

lastly `std.meta.trait.isUnsignedInt()` seems to be removed. Now using `std.meta.Int()` , and following a similar pattern found in handles.zig

```zig
    std.debug.assert(std.meta.trait.isUnsignedInt(EntityType));
    // Now becomes
    std.debug.assert(@typeInfo(EntityType) == .Int and std.meta.Int(.unsigned, @bitSizeOf(EntityType)) == EntityType);
```