### PR TITLE
Delegate now support multiple params

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,11 @@
+.{
+  .name = "entt",
+  .version = "1.0.0",
+  .paths = .{
+    "src",
+    "tests",
+    "examples",
+    "build.zig",
+    "build.zig.zon",
+  },
+}

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -326,7 +326,7 @@ pub const Registry = struct {
         const store = self.assure(@TypeOf(value));
         if (store.tryGet(entity)) |found| {
             found.* = value;
-            store.update.publish(entity);
+            store.update.publish(.{ self, entity });
         } else {
             store.add(entity, value);
         }
@@ -338,7 +338,7 @@ pub const Registry = struct {
 
         const store = self.assure(T);
         if (store.contains(entity)) {
-            store.update.publish(entity);
+            store.update.publish(.{ self, entity });
         }
     }
 
@@ -350,7 +350,7 @@ pub const Registry = struct {
         if (store.tryGet(entity)) |found| {
             const old = found.*;
             found.* = value;
-            store.update.publish(entity);
+            store.update.publish(.{ self, entity });
             return old;
         } else {
             store.add(entity, value);

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -46,10 +46,9 @@ pub const Registry = struct {
         owned: []u32,
         include: []u32,
         exclude: []u32,
-        registry: *Registry,
         current: usize,
 
-        pub fn initPtr(allocator: std.mem.Allocator, registry: *Registry, hash: u64, owned: []u32, include: []u32, exclude: []u32) *GroupData {
+        pub fn initPtr(allocator: std.mem.Allocator, hash: u64, owned: []u32, include: []u32, exclude: []u32) *GroupData {
             // std.debug.assert(std.mem.indexOfAny(u32, owned, include) == null);
             // std.debug.assert(std.mem.indexOfAny(u32, owned, exclude) == null);
             // std.debug.assert(std.mem.indexOfAny(u32, include, exclude) == null);
@@ -62,7 +61,6 @@ pub const Registry = struct {
             group_data.owned = allocator.dupe(u32, owned) catch unreachable;
             group_data.include = allocator.dupe(u32, include) catch unreachable;
             group_data.exclude = allocator.dupe(u32, exclude) catch unreachable;
-            group_data.registry = registry;
             group_data.current = 0;
 
             return group_data;
@@ -79,22 +77,22 @@ pub const Registry = struct {
             allocator.destroy(self);
         }
 
-        pub fn maybeValidIf(self: *GroupData, entity: Entity) void {
+        pub fn maybeValidIf(self: *GroupData, registry: *Registry, entity: Entity) void {
             const isValid: bool = blk: {
                 for (self.owned) |tid| {
-                    const ptr = self.registry.components.get(tid).?;
+                    const ptr = registry.components.get(tid).?;
                     if (!@as(*Storage(u1), @ptrFromInt(ptr)).contains(entity))
                         break :blk false;
                 }
 
                 for (self.include) |tid| {
-                    const ptr = self.registry.components.get(tid).?;
+                    const ptr = registry.components.get(tid).?;
                     if (!@as(*Storage(u1), @ptrFromInt(ptr)).contains(entity))
                         break :blk false;
                 }
 
                 for (self.exclude) |tid| {
-                    const ptr = self.registry.components.get(tid).?;
+                    const ptr = registry.components.get(tid).?;
                     if (@as(*Storage(u1), @ptrFromInt(ptr)).contains(entity))
                         break :blk false;
                 }
@@ -107,11 +105,11 @@ pub const Registry = struct {
                 }
             } else {
                 if (isValid) {
-                    const ptr = self.registry.components.get(self.owned[0]).?;
+                    const ptr = registry.components.get(self.owned[0]).?;
                     if (!(@as(*Storage(u1), @ptrFromInt(ptr)).set.index(entity) < self.current)) {
                         for (self.owned) |tid| {
                             // store.swap hides a safe version that types it correctly
-                            const store_ptr = self.registry.components.get(tid).?;
+                            const store_ptr = registry.components.get(tid).?;
                             var store = @as(*Storage(u1), @ptrFromInt(store_ptr));
                             store.swap(store.data()[self.current], entity);
                         }
@@ -122,18 +120,18 @@ pub const Registry = struct {
             }
         }
 
-        pub fn discardIf(self: *GroupData, entity: Entity) void {
+        pub fn discardIf(self: *GroupData, registry: *Registry, entity: Entity) void {
             if (self.owned.len == 0) {
                 if (self.entity_set.contains(entity)) {
                     self.entity_set.remove(entity);
                 }
             } else {
-                const ptr = self.registry.components.get(self.owned[0]).?;
+                const ptr = registry.components.get(self.owned[0]).?;
                 var store = @as(*Storage(u1), @ptrFromInt(ptr));
                 if (store.contains(entity) and store.set.index(entity) < self.current) {
                     self.current -= 1;
                     for (self.owned) |tid| {
-                        const store_ptr = self.registry.components.get(tid).?;
+                        const store_ptr = registry.components.get(tid).?;
                         store = @as(*Storage(u1), @ptrFromInt(store_ptr));
                         store.swap(store.data()[self.current], entity);
                     }
@@ -225,6 +223,7 @@ pub const Registry = struct {
         }
 
         const comp_set = Storage(T).initPtr(self.allocator);
+        comp_set.registry = self;
         const comp_set_ptr = @intFromPtr(comp_set);
         _ = self.components.put(type_id, comp_set_ptr) catch unreachable;
         return comp_set;
@@ -442,17 +441,17 @@ pub const Registry = struct {
     }
 
     /// Returns a Sink object for the given component to add/remove listeners with
-    pub fn onConstruct(self: *Registry, comptime T: type) Sink(Entity) {
+    pub fn onConstruct(self: *Registry, comptime T: type) Sink(.{*Registry, Entity}) {
         return self.assure(T).onConstruct();
     }
 
     /// Returns a Sink object for the given component to add/remove listeners with
-    pub fn onUpdate(self: *Registry, comptime T: type) Sink(Entity) {
+    pub fn onUpdate(self: *Registry, comptime T: type) Sink(.{*Registry, Entity}) {
         return self.assure(T).onUpdate();
     }
 
     /// Returns a Sink object for the given component to add/remove listeners with
-    pub fn onDestruct(self: *Registry, comptime T: type) Sink(Entity) {
+    pub fn onDestruct(self: *Registry, comptime T: type) Sink(.{*Registry, Entity}) {
         return self.assure(T).onDestruct();
     }
 
@@ -577,7 +576,7 @@ pub const Registry = struct {
         }
 
         // we need to create a new GroupData
-        var new_group_data = GroupData.initPtr(self.allocator, self, hash, owned_arr[0..], includes_arr[0..], excludes_arr[0..]);
+        var new_group_data = GroupData.initPtr(self.allocator, hash, owned_arr[0..], includes_arr[0..], excludes_arr[0..]);
 
         // before adding the group we need to do some checks to make sure there arent other owning groups with the same types
         if (builtin.mode == .Debug and owned.len > 0) {
@@ -631,13 +630,13 @@ pub const Registry = struct {
         }
 
         // wire up our listeners
-        inline for (owned) |t| self.onConstruct(t).beforeBound(maybe_valid_if).connectBound(new_group_data, "maybeValidIf");
-        inline for (includes) |t| self.onConstruct(t).beforeBound(maybe_valid_if).connectBound(new_group_data, "maybeValidIf");
-        inline for (excludes) |t| self.onDestruct(t).beforeBound(maybe_valid_if).connectBound(new_group_data, "maybeValidIf");
+        inline for (owned) |t| self.onConstruct(t).beforeBound(maybe_valid_if).connectBound(new_group_data, GroupData.maybeValidIf);
+        inline for (includes) |t| self.onConstruct(t).beforeBound(maybe_valid_if).connectBound(new_group_data, GroupData.maybeValidIf);
+        inline for (excludes) |t| self.onDestruct(t).beforeBound(maybe_valid_if).connectBound(new_group_data, GroupData.maybeValidIf);
 
-        inline for (owned) |t| self.onDestruct(t).beforeBound(discard_if).connectBound(new_group_data, "discardIf");
-        inline for (includes) |t| self.onDestruct(t).beforeBound(discard_if).connectBound(new_group_data, "discardIf");
-        inline for (excludes) |t| self.onConstruct(t).beforeBound(discard_if).connectBound(new_group_data, "discardIf");
+        inline for (owned) |t| self.onDestruct(t).beforeBound(discard_if).connectBound(new_group_data, GroupData.discardIf);
+        inline for (includes) |t| self.onDestruct(t).beforeBound(discard_if).connectBound(new_group_data, GroupData.discardIf);
+        inline for (excludes) |t| self.onConstruct(t).beforeBound(discard_if).connectBound(new_group_data, GroupData.discardIf);
 
         // pre-fill the GroupData with any existing entitites that match
         if (owned.len == 0) {
@@ -651,7 +650,7 @@ pub const Registry = struct {
             // ??? why not?
             var first_owned_storage = self.assure(owned[0]);
             for (first_owned_storage.data()) |entity| {
-                new_group_data.maybeValidIf(entity);
+                new_group_data.maybeValidIf(self, entity);
             }
             // for(auto *first = std::get<0>(cpools).data(), *last = first + std::get<0>(cpools).size(); first != last; ++first) {
             //     handler->template maybe_valid_if<std::tuple_element_t<0, std::tuple<std::decay_t<Owned>...>>>(*this, *first);

--- a/src/signals/sink.zig
+++ b/src/signals/sink.zig
@@ -1,25 +1,33 @@
 const std = @import("std");
 const Signal = @import("signal.zig").Signal;
-const Delegate = @import("delegate.zig").Delegate;
+const SignalFromTuple = @import("signal.zig").SignalFromTuple;
+const Delegate = @import("delegate.zig").DelegateFromTuple;
+const Tuple = @import("delegate.zig").Tuple;
 
 /// helper used to connect and disconnect listeners on the fly from a Signal. Listeners are wrapped in Delegates
 /// and can be either free functions or functions bound to a struct.
-pub fn Sink(comptime Event: type) type {
+pub fn Sink(comptime Params: anytype) type {
+  return SinkFromTuple(Tuple(Params));
+}
+
+/// helper used to connect and disconnect listeners on the fly from a Signal. Listeners are wrapped in Delegates
+/// and can be either free functions or functions bound to a struct.
+pub fn SinkFromTuple(comptime Params: type) type {
     return struct {
         const Self = @This();
 
         insert_index: usize,
 
         /// the Signal this Sink is temporarily wrapping
-        var owning_signal: *Signal(Event) = undefined;
+        var owning_signal: *SignalFromTuple(Params) = undefined;
 
-        pub fn init(signal: *Signal(Event)) Self {
+        pub fn init(signal: *SignalFromTuple(Params)) Self {
             owning_signal = signal;
             return Self{ .insert_index = owning_signal.calls.items.len };
         }
 
-        pub fn before(self: Self, callback: ?*const fn (Event) void) Self {
-            if (callback) |cb| {
+        pub fn before(self: Self, free_fn: ?Delegate(Params).FreeFn) Self {
+            if (free_fn) |cb| {
                 if (self.indexOf(cb)) |index| {
                     return Self{ .insert_index = index };
                 }
@@ -27,53 +35,53 @@ pub fn Sink(comptime Event: type) type {
             return self;
         }
 
-        pub fn beforeBound(self: Self, ctx: anytype) Self {
-            if (@typeInfo(@TypeOf(ctx)) == .Pointer) {
-                if (self.indexOfBound(ctx)) |index| {
+        pub fn beforeBound(self: Self, ctx_ptr: anytype) Self {
+            if (@typeInfo(@TypeOf(ctx_ptr)) == .Pointer) {
+                if (self.indexOfBound(ctx_ptr)) |index| {
                     return Self{ .insert_index = index };
                 }
             }
             return self;
         }
 
-        /// connects a callback `fn(Event) void` to this sink
-        /// NOTE: each callback can only be connected ONCE to the same sink
-        pub fn connect(self: Self, callback: *const fn (Event) void) void {
-            std.debug.assert(self.indexOf(callback) == null);
-            _ = owning_signal.calls.insert(self.insert_index, Delegate(Event).initFree(callback)) catch unreachable;
+        /// connects a callback `Delegate(Params).FreeFn` to this sink
+        /// NOTE: each free_fn can only be connected ONCE to the same sink
+        pub fn connect(self: Self, free_fn: Delegate(Params).FreeFn) void {
+            std.debug.assert(self.indexOf(free_fn) == null);
+            _ = owning_signal.calls.insert(self.insert_index, Delegate(Params).initFree(free_fn)) catch unreachable;
         }
 
-        /// connects a context `fn ctx.fn_name(Event) void` to this sink
-        /// NOTE: each context can only be connected ONCE to the same sink
-        pub fn connectBound(self: Self, ctx: anytype, comptime fn_name: []const u8) void {
-            std.debug.assert(self.indexOfBound(ctx) == null);
-            _ = owning_signal.calls.insert(self.insert_index, Delegate(Event).initBound(ctx, fn_name)) catch unreachable;
+        /// connects a context `Delegate(Params).BindFn(@TypeOf(ctx_ptr))` to this sink
+        /// NOTE: each ctx_ptr can only be connected ONCE to the same sink
+        pub fn connectBound(self: Self, ctx_ptr: anytype, bind_fn: Delegate(Params).BindFn(@TypeOf(ctx_ptr))) void {
+            std.debug.assert(self.indexOfBound(ctx_ptr) == null);
+            _ = owning_signal.calls.insert(self.insert_index, Delegate(Params).initBind(ctx_ptr, bind_fn)) catch unreachable;
         }
 
-        pub fn disconnect(self: Self, callback: *const fn (Event) void) void {
-            if (self.indexOf(callback)) |index| {
+        pub fn disconnect(self: Self, free_fn: Delegate(Params).FreeFn) void {
+            if (self.indexOf(free_fn)) |index| {
                 _ = owning_signal.calls.swapRemove(index);
             }
         }
 
-        pub fn disconnectBound(self: Self, ctx: anytype) void {
-            if (self.indexOfBound(ctx)) |index| {
+        pub fn disconnectBound(self: Self, ctx_ptr: anytype) void {
+            if (self.indexOfBound(ctx_ptr)) |index| {
                 _ = owning_signal.calls.swapRemove(index);
             }
         }
 
-        fn indexOf(_: Self, callback: *const fn (Event) void) ?usize {
+        fn indexOf(_: Self, free_fn: Delegate(Params).FreeFn) ?usize {
             for (owning_signal.calls.items, 0..) |call, i| {
-                if (call.containsFree(callback)) {
+                if (call.containsFree(free_fn)) {
                     return i;
                 }
             }
             return null;
         }
 
-        fn indexOfBound(_: Self, ctx: anytype) ?usize {
+        fn indexOfBound(_: Self, ctx_ptr: anytype) ?usize {
             for (owning_signal.calls.items, 0..) |call, i| {
-                if (call.containsBound(ctx)) {
+                if (call.containsBound(ctx_ptr)) {
                     return i;
                 }
             }
@@ -95,23 +103,23 @@ const Thing = struct {
 };
 
 test "Sink Before free" {
-    var signal = Signal(u32).init(std.testing.allocator);
+    var signal = Signal(.{u32}).init(std.testing.allocator);
     defer signal.deinit();
 
     signal.sink().connect(tester);
     try std.testing.expectEqual(signal.sink().indexOf(tester).?, 0);
 
     var thing = Thing{};
-    signal.sink().before(tester).connectBound(&thing, "tester");
+    signal.sink().before(tester).connectBound(&thing, &Thing.tester);
     try std.testing.expectEqual(signal.sink().indexOfBound(&thing).?, 0);
 }
 
 test "Sink Before bound" {
-    var signal = Signal(u32).init(std.testing.allocator);
+    var signal = Signal(.{u32}).init(std.testing.allocator);
     defer signal.deinit();
 
     var thing = Thing{};
-    signal.sink().connectBound(&thing, "tester");
+    signal.sink().connectBound(&thing, &Thing.tester);
     try std.testing.expectEqual(signal.sink().indexOfBound(&thing).?, 0);
 
     signal.sink().beforeBound(&thing).connect(tester);

--- a/tests/dispatcher_test.zig
+++ b/tests/dispatcher_test.zig
@@ -27,13 +27,13 @@ test "Dispatcher" {
     var d = Dispatcher.init(std.testing.allocator);
     defer d.deinit();
 
-    var sink = d.sink(u32);
+    var sink = d.sink(.{u32});
     sink.connect(tester);
-    sink.connectBound(&thing, "testU32");
-    d.trigger(u32, 666);
+    sink.connectBound(&thing, Thing.testU32);
+    d.trigger(.{u32}, .{666});
 
-    var sink2 = d.sink(i32);
+    var sink2 = d.sink(.{i32});
     sink2.connect(tester2);
-    sink2.connectBound(&thing, "testI32");
-    d.trigger(i32, -543);
+    sink2.connectBound(&thing, Thing.testI32);
+    d.trigger(.{i32}, .{-543});
 }

--- a/zig.mod
+++ b/zig.mod
@@ -1,4 +1,0 @@
-id: 8cw92n7j19xzpjm8kwq0scvx3vx6k7b730vn3i6rl3t25z08
-name: ecs
-main: src/ecs.zig
-dependencies:


### PR DESCRIPTION
1. delegate support multiple params.
2. delegate support runtime bind/free function pointer.
3. lifecycle callback function type changed to fn(*Registry, Entity) to better match original entt.