### PR TITLE
Update to zig 0.13.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
     const ecs_module = b.addModule("zig-ecs", .{
-        .root_source_file = .{.path = "src/ecs.zig"},
+        .root_source_file = b.path("src/ecs.zig"),
         .optimize = optimize,
         .target = target,
     });
@@ -22,7 +22,7 @@ pub fn build(b: *std.Build) void {
 
         const exe = b.addExecutable(.{
             .name = name,
-            .root_source_file = .{.path = source},
+            .root_source_file = b.path(source),
             .optimize = optimize,
             .target = target,
         });
@@ -49,7 +49,7 @@ pub fn build(b: *std.Build) void {
 
     // internal tests
     const internal_test = b.addTest(.{
-        .root_source_file = .{.path = "src/tests.zig"},
+        .root_source_file = b.path("src/tests.zig"),
         .optimize = optimize,
         .target = target,
         .name = "internal_tests",
@@ -58,7 +58,7 @@ pub fn build(b: *std.Build) void {
 
     // public api tests
     const public_test = b.addTest(.{
-        .root_source_file = .{.path = "tests/tests.zig"},
+        .root_source_file = b.path("tests/tests.zig"),
         .optimize = optimize,
         .target = target,
         .name = "public_tests",
@@ -80,7 +80,7 @@ pub const LibType = enum(i32) {
 
 pub fn getModule(b: *std.Build, comptime prefix_path: []const u8) *std.Build.Module {
     return b.addModule(.{
-        .root_source_file = .{.path = prefix_path ++ "src/ecs.zig"},
+        .root_source_file = b.path(prefix_path ++ "src/ecs.zig"),
         .target = b.standardTargetOptions(.{}),
         .optimize = b.standardOptimizeOption(.{}),
         .name = "ecs",

--- a/src/process/process.zig
+++ b/src/process/process.zig
@@ -17,7 +17,7 @@ pub const Process = struct {
     next: ?*Process = null,
 
     pub fn getParent(self: *Process, comptime T: type) *T {
-        return @fieldParentPtr(T, "process", self);
+        return @fieldParentPtr("process", self);
     }
 
     /// Terminates a process with success if it's still alive

--- a/src/process/scheduler.zig
+++ b/src/process/scheduler.zig
@@ -25,7 +25,7 @@ pub const Scheduler = struct {
                 if (process.next) |next_process| {
                     next_process.deinit(next_process, alloc);
                 }
-                alloc.destroy(@fieldParentPtr(T, "process", process));
+                alloc.destroy(@as(*T, @fieldParentPtr("process", process)));
             }
         }.deinit;
 

--- a/src/signals/delegate.zig
+++ b/src/signals/delegate.zig
@@ -27,7 +27,6 @@ pub fn DelegateFromTuple(comptime Params: type) type {
             }
             return *const @Type(.{.Fn = .{
                 .calling_convention = .Unspecified,
-                .alignment = 1,
                 .is_generic = false,
                 .is_var_args = false,
                 .return_type = void,
@@ -91,7 +90,6 @@ fn Fn(comptime Params: type) type {
     }
     return *const @Type(.{.Fn = .{
         .calling_convention = .Unspecified,
-        .alignment = 1,
         .is_generic = false,
         .is_var_args = false,
         .return_type = void,


### PR DESCRIPTION
- Fixed path errors in `build.zig`.
- The `Fn` structure no longer contains `alignment` field.
- `@fieldParentPtr` no longer contains a type parameter.