### PR TITLE
Compilation fix

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -80,7 +80,7 @@ pub const LibType = enum(i32) {
 
 pub fn getModule(b: *std.Build, comptime prefix_path: []const u8) *std.Build.Module {
     return b.addModule(.{
-        .root_source_file = .{.path = prefix_path ++ "src/ecs.zig"},
+        .root_source_file = b.path(prefix_path ++ "src/ecs.zig"),
         .target = b.standardTargetOptions(.{}),
         .optimize = b.standardOptimizeOption(.{}),
         .name = "ecs",

--- a/src/ecs/groups.zig
+++ b/src/ecs/groups.zig
@@ -79,14 +79,14 @@ pub const OwningGroup = struct {
             group: OwningGroup,
             index: usize,
             storage: *Storage(u1),
-            component_ptrs: [@typeInfo(Components).@"struct".fields.len][*]u8,
+            component_ptrs: [@typeInfo(Components).Struct.fields.len][*]u8,
 
             pub fn init(group: OwningGroup) @This() {
-                const component_info = @typeInfo(Components).@"struct";
+                const component_info = @typeInfo(Components).Struct;
 
                 var component_ptrs: [component_info.fields.len][*]u8 = undefined;
                 inline for (component_info.fields, 0..) |field, i| {
-                    const storage = group.registry.assure(@typeInfo(field.type).pointer.child);
+                    const storage = group.registry.assure(@typeInfo(field.type).Pointer.child);
                     component_ptrs[i] = @as([*]u8, @ptrCast(storage.instances.items.ptr));
                 }
 
@@ -104,8 +104,8 @@ pub const OwningGroup = struct {
 
                 // fill and return the struct
                 var comps: Components = undefined;
-                inline for (@typeInfo(Components).@"struct".fields, 0..) |field, i| {
-                    const typed_ptr = @as([*]@typeInfo(field.type).pointer.child, @ptrCast(@alignCast(it.component_ptrs[i])));
+                inline for (@typeInfo(Components).Struct.fields, 0..) |field, i| {
+                    const typed_ptr = @as([*]@typeInfo(field.type).Pointer.child, @ptrCast(@alignCast(it.component_ptrs[i])));
                     @field(comps, field.name) = &typed_ptr[it.index];
                 }
                 return comps;
@@ -158,10 +158,10 @@ pub const OwningGroup = struct {
 
     fn validate(self: OwningGroup, comptime Components: anytype) void {
         if (builtin.mode == .Debug and self.group_data.owned.len > 0) {
-            std.debug.assert(@typeInfo(Components) == .@"struct");
+            std.debug.assert(@typeInfo(Components) == .Struct);
 
-            inline for (@typeInfo(Components).@"struct".fields) |field| {
-                std.debug.assert(@typeInfo(field.type) == .pointer);
+            inline for (@typeInfo(Components).Struct.fields) |field| {
+                std.debug.assert(@typeInfo(field.type) == .Pointer);
                 const found = std.mem.indexOfScalar(u32, self.group_data.owned, utils.typeId(std.meta.Child(field.type)));
                 std.debug.assert(found != null);
             }
@@ -170,7 +170,7 @@ pub const OwningGroup = struct {
 
     pub fn getOwned(self: OwningGroup, entity: Entity, comptime Components: anytype) Components {
         self.validate(Components);
-        const component_info = @typeInfo(Components).@"struct";
+        const component_info = @typeInfo(Components).Struct;
 
         var component_ptrs: [component_info.fields.len][*]u8 = undefined;
         inline for (component_info.fields, 0..) |field, i| {
@@ -191,7 +191,7 @@ pub const OwningGroup = struct {
 
     pub fn each(self: OwningGroup, comptime func: anytype) void {
         const Components = switch (@typeInfo(@TypeOf(func))) {
-            .@"fn" => |func_info| func_info.params[0].type.?,
+            .Fn => |func_info| func_info.params[0].type.?,
             else => std.debug.assert("invalid func"),
         };
         self.validate(Components);

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -213,7 +213,7 @@ pub const Registry = struct {
     }
 
     pub fn assure(self: *Registry, comptime T: type) *Storage(T) {
-        if (@typeInfo(@TypeOf(T)) == .pointer) {
+        if (@typeInfo(@TypeOf(T)) == .Pointer) {
             @compileError("assure must receive a value, not a pointer. Received: " ++ @typeName(T));
         }
 
@@ -311,7 +311,7 @@ pub const Registry = struct {
 
     /// shortcut for replacing raw comptime_int/float without having to @as cast
     pub fn replaceTyped(self: *Registry, comptime T: type, entity: Entity, value: T) void {
-        if (@typeInfo(@TypeOf(value)) == .pointer) {
+        if (@typeInfo(@TypeOf(value)) == .Pointer) {
             @compileError("replaceTyped must receive a value, not a pointer. Received: " ++ @typeName(@TypeOf(value)));
         }
         self.replace(entity, value);
@@ -319,7 +319,7 @@ pub const Registry = struct {
 
     pub fn addOrReplace(self: *Registry, entity: Entity, value: anytype) void {
         assert(self.valid(entity));
-        if (@typeInfo(@TypeOf(value)) == .pointer) {
+        if (@typeInfo(@TypeOf(value)) == .Pointer) {
             @compileError("addOrReplace must receive a value, not a pointer. Received: " ++ @typeName(@TypeOf(value)));
         }
 
@@ -457,21 +457,21 @@ pub const Registry = struct {
 
     /// Binds an object to the context of the registry
     pub fn setContext(self: *Registry, context: anytype) void {
-        std.debug.assert(@typeInfo(@TypeOf(context)) == .pointer);
+        std.debug.assert(@typeInfo(@TypeOf(context)) == .Pointer);
 
-        const type_id = utils.typeId(@typeInfo(@TypeOf(context)).pointer.child);
+        const type_id = utils.typeId(@typeInfo(@TypeOf(context)).Pointer.child);
         _ = self.contexts.put(type_id, @intFromPtr(context)) catch unreachable;
     }
 
     /// Unsets a context variable if it exists
     pub fn unsetContext(self: *Registry, comptime T: type) void {
-        std.debug.assert(@typeInfo(T) != .pointer);
+        std.debug.assert(@typeInfo(T) != .Pointer);
         _ = self.contexts.put(utils.typeId(T), 0) catch unreachable;
     }
 
     /// Returns a pointer to an object in the context of the registry
     pub fn getContext(self: *Registry, comptime T: type) ?*T {
-        std.debug.assert(@typeInfo(T) != .pointer);
+        std.debug.assert(@typeInfo(T) != .Pointer);
 
         return if (self.contexts.get(utils.typeId(T))) |ptr|
             return if (ptr > 0) @as(*T, @ptrFromInt(ptr)) else null
@@ -496,8 +496,8 @@ pub const Registry = struct {
     }
 
     pub fn view(self: *Registry, comptime includes: anytype, comptime excludes: anytype) ViewType(includes, excludes) {
-        std.debug.assert(@typeInfo(@TypeOf(includes)) == .@"struct");
-        std.debug.assert(@typeInfo(@TypeOf(excludes)) == .@"struct");
+        std.debug.assert(@typeInfo(@TypeOf(includes)) == .Struct);
+        std.debug.assert(@typeInfo(@TypeOf(excludes)) == .Struct);
         std.debug.assert(includes.len > 0);
 
         // just one include so use the optimized BasicView
@@ -537,9 +537,9 @@ pub const Registry = struct {
 
     /// creates an optimized group for iterating components
     pub fn group(self: *Registry, comptime owned: anytype, comptime includes: anytype, comptime excludes: anytype) (if (owned.len == 0) BasicGroup else OwningGroup) {
-        std.debug.assert(@typeInfo(@TypeOf(owned)) == .@"struct");
-        std.debug.assert(@typeInfo(@TypeOf(includes)) == .@"struct");
-        std.debug.assert(@typeInfo(@TypeOf(excludes)) == .@"struct");
+        std.debug.assert(@typeInfo(@TypeOf(owned)) == .Struct);
+        std.debug.assert(@typeInfo(@TypeOf(includes)) == .Struct);
+        std.debug.assert(@typeInfo(@TypeOf(excludes)) == .Struct);
         std.debug.assert(owned.len + includes.len > 0);
         std.debug.assert(owned.len + includes.len + excludes.len >= 1);
 

--- a/src/ecs/utils.zig
+++ b/src/ecs/utils.zig
@@ -142,7 +142,7 @@ pub fn hashStringDjb2(comptime str: []const u8) comptime_int {
 
 pub fn isComptime(comptime T: type) bool {
     return switch (@typeInfo(T)) {
-        .comptime_int, .comptime_float => true,
+        .ComptimeInt, .ComptimeFloat => true,
         else => false,
     };
 }

--- a/src/resources/assets.zig
+++ b/src/resources/assets.zig
@@ -38,7 +38,7 @@ pub const Assets = struct {
     }
 
     fn ReturnType(comptime loader: anytype, comptime strip_ptr: bool) type {
-        const ret = @typeInfo(@typeInfo(@TypeOf(@field(loader, "load"))).pointer.child).@"fn".return_type.?;
+        const ret = @typeInfo(@typeInfo(@TypeOf(@field(loader, "load"))).Pointer.child).Fn.return_type.?;
         if (strip_ptr) {
             return std.meta.Child(ret);
         }

--- a/src/resources/cache.zig
+++ b/src/resources/cache.zig
@@ -42,7 +42,7 @@ pub fn Cache(comptime T: type) type {
             self.safe_deinit(self);
         }
 
-        pub fn load(self: *@This(), id: u32, comptime loader: anytype) @typeInfo(@typeInfo(@TypeOf(@field(loader, "load"))).pointer.child).@"fn".return_type.? {
+        pub fn load(self: *@This(), id: u32, comptime loader: anytype) @typeInfo(@typeInfo(@TypeOf(@field(loader, "load"))).Pointer.child).Fn.return_type.? {
             if (self.resources.get(id)) |resource| {
                 return resource;
             }

--- a/src/signals/delegate.zig
+++ b/src/signals/delegate.zig
@@ -25,7 +25,7 @@ pub fn DelegateFromTuple(comptime Params: type) type {
                     .type = field.type,
                 };
             }
-            return *const @Type(.{ .@"fn" = .{
+            return *const @Type(.{ .Fn = .{
                 .calling_convention = .Unspecified,
                 .is_generic = false,
                 .is_var_args = false,
@@ -88,7 +88,7 @@ fn Fn(comptime Params: type) type {
             .type = field.type,
         };
     }
-    return *const @Type(.{ .@"fn" = .{
+    return *const @Type(.{ .Fn = .{
         .calling_convention = .Unspecified,
         .is_generic = false,
         .is_var_args = false,

--- a/src/signals/sink.zig
+++ b/src/signals/sink.zig
@@ -36,7 +36,7 @@ pub fn SinkFromTuple(comptime Params: type) type {
         }
 
         pub fn beforeBound(self: Self, ctx_ptr: anytype) Self {
-            if (@typeInfo(@TypeOf(ctx_ptr)) == .pointer) {
+            if (@typeInfo(@TypeOf(ctx_ptr)) == .Pointer) {
                 if (self.indexOfBound(ctx_ptr)) |index| {
                     return Self{ .insert_index = index };
                 }


### PR DESCRIPTION
Fix compilation errors for Zig 0.13.0:
- Renamed type info enum variants
- Apply a refactor for `root_source_file` that was missed in one place