### PR TITLE
Use unmanaged lists

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -58,7 +58,7 @@ pub fn build(b: *std.Build) void {
 
     // public api tests
     const public_test = b.addTest(.{
-        .root_source_file = b.path("src/tests.zig"),
+        .root_source_file = b.path("tests/tests.zig"),
         .optimize = optimize,
         .target = target,
         .name = "public_tests",

--- a/src/ecs/component_storage.zig
+++ b/src/ecs/component_storage.zig
@@ -23,8 +23,8 @@ pub fn ComponentStorage(comptime Component: type, comptime Entity: type) type {
         const Self = @This();
 
         set: *SparseSet(Entity),
-        instances: std.ArrayList(ComponentOrDummy),
-        allocator: ?std.mem.Allocator,
+        instances: std.ArrayListUnmanaged(ComponentOrDummy),
+        allocator: std.mem.Allocator,
         /// doesnt really belong here...used to denote group ownership
         super: usize = 0,
         safeDeinit: *const fn (*Self) void,
@@ -36,6 +36,18 @@ pub fn ComponentStorage(comptime Component: type, comptime Entity: type) type {
         update: Signal(.{ *Registry, Entity }),
         destruction: Signal(.{ *Registry, Entity }),
 
+        pub fn create(allocator: std.mem.Allocator) *Self {
+            const store = allocator.create(Self) catch unreachable;
+            store.* = Self.init(allocator);
+            return store;
+        }
+
+        pub fn destroy(self: *Self) void {
+            const allocator = self.allocator;
+            self.deinit();
+            allocator.destroy(self);
+        }
+
         pub fn init(allocator: std.mem.Allocator) Self {
             var store = Self{
                 .set = SparseSet(Entity).create(allocator),
@@ -43,7 +55,7 @@ pub fn ComponentStorage(comptime Component: type, comptime Entity: type) type {
                 .safeDeinit = struct {
                     fn deinit(self: *Self) void {
                         if (!is_empty_struct) {
-                            self.instances.deinit();
+                            self.instances.deinit(self.allocator);
                         }
                     }
                 }.deinit,
@@ -62,56 +74,15 @@ pub fn ComponentStorage(comptime Component: type, comptime Entity: type) type {
                         }
                     }
                 }.removeIfContains,
-                .allocator = null,
+                .allocator = allocator,
                 .construction = Signal(.{ *Registry, Entity }).init(allocator),
                 .update = Signal(.{ *Registry, Entity }).init(allocator),
                 .destruction = Signal(.{ *Registry, Entity }).init(allocator),
             };
 
             if (!is_empty_struct) {
-                store.instances = std.ArrayList(ComponentOrDummy).init(allocator);
+                store.instances = std.ArrayListUnmanaged(ComponentOrDummy){};
             }
-
-            return store;
-        }
-
-        pub fn initPtr(allocator: std.mem.Allocator) *Self {
-            var store = allocator.create(Self) catch unreachable;
-            store.set = SparseSet(Entity).create(allocator);
-            if (!is_empty_struct) {
-                store.instances = std.ArrayList(ComponentOrDummy).init(allocator);
-            }
-            store.allocator = allocator;
-            store.super = 0;
-            store.construction = Signal(.{ *Registry, Entity }).init(allocator);
-            store.update = Signal(.{ *Registry, Entity }).init(allocator);
-            store.destruction = Signal(.{ *Registry, Entity }).init(allocator);
-
-            // since we are stored as a pointer, we need to catpure this
-            store.safeDeinit = struct {
-                fn deinit(self: *Self) void {
-                    if (!is_empty_struct) {
-                        self.instances.deinit();
-                    }
-                }
-            }.deinit;
-
-            store.safeSwap = struct {
-                fn swap(self: *Self, lhs: Entity, rhs: Entity, instances_only: bool) void {
-                    if (!is_empty_struct) {
-                        std.mem.swap(Component, &self.instances.items[self.set.index(lhs)], &self.instances.items[self.set.index(rhs)]);
-                    }
-                    if (!instances_only) self.set.swap(lhs, rhs);
-                }
-            }.swap;
-
-            store.safeRemoveIfContains = struct {
-                fn removeIfContains(self: *Self, entity: Entity) void {
-                    if (self.contains(entity)) {
-                        self.remove(entity);
-                    }
-                }
-            }.removeIfContains;
 
             return store;
         }
@@ -125,10 +96,6 @@ pub fn ComponentStorage(comptime Component: type, comptime Entity: type) type {
             self.construction.deinit();
             self.update.deinit();
             self.destruction.deinit();
-
-            if (self.allocator) |allocator| {
-                allocator.destroy(self);
-            }
         }
 
         pub fn onConstruct(self: *Self) Sink(.{ *Registry, Entity }) {
@@ -154,7 +121,7 @@ pub fn ComponentStorage(comptime Component: type, comptime Entity: type) type {
         /// Assigns an entity to a storage and assigns its object
         pub fn add(self: *Self, entity: Entity, value: Component) void {
             if (!is_empty_struct) {
-                _ = self.instances.append(value) catch unreachable;
+                _ = self.instances.append(self.allocator, value) catch unreachable;
             }
             self.set.add(entity);
             self.construction.publish(.{ self.registry, entity });
@@ -322,8 +289,8 @@ test "add/get/remove" {
 }
 
 test "iterate" {
-    var store = ComponentStorage(f32, u32).initPtr(std.testing.allocator);
-    defer store.deinit();
+    var store = ComponentStorage(f32, u32).create(std.testing.allocator);
+    defer store.destroy();
 
     store.add(3, 66.45);
     store.add(5, 66.45);
@@ -345,8 +312,8 @@ test "iterate" {
 test "empty component" {
     const Empty = struct {};
 
-    var store = ComponentStorage(Empty, u32).initPtr(std.testing.allocator);
-    defer store.deinit();
+    var store = ComponentStorage(Empty, u32).create(std.testing.allocator);
+    defer store.destroy();
 
     store.add(3, Empty{});
     store.remove(3);
@@ -386,8 +353,8 @@ test "signals" {
 test "sort empty component" {
     const Empty = struct {};
 
-    var store = ComponentStorage(Empty, u32).initPtr(std.testing.allocator);
-    defer store.deinit();
+    var store = ComponentStorage(Empty, u32).create(std.testing.allocator);
+    defer store.destroy();
 
     store.add(1, Empty{});
     store.add(2, Empty{});
@@ -409,8 +376,8 @@ test "sort empty component" {
 }
 
 test "sort by entity" {
-    var store = ComponentStorage(f32, u32).initPtr(std.testing.allocator);
-    defer store.deinit();
+    var store = ComponentStorage(f32, u32).create(std.testing.allocator);
+    defer store.destroy();
 
     store.add(22, @as(f32, 2.2));
     store.add(11, @as(f32, 1.1));
@@ -436,8 +403,8 @@ test "sort by entity" {
 }
 
 test "sort by component" {
-    var store = ComponentStorage(f32, u32).initPtr(std.testing.allocator);
-    defer store.deinit();
+    var store = ComponentStorage(f32, u32).create(std.testing.allocator);
+    defer store.destroy();
 
     store.add(22, @as(f32, 2.2));
     store.add(11, @as(f32, 1.1));

--- a/src/resources/assets.zig
+++ b/src/resources/assets.zig
@@ -17,7 +17,7 @@ pub const Assets = struct {
         var iter = self.caches.iterator();
         while (iter.next()) |ptr| {
             // HACK: we dont know the Type here but we need to call deinit
-            @as(*Cache(u1), @ptrFromInt(ptr.value_ptr.*)).deinit();
+            @as(*Cache(u1), @ptrFromInt(ptr.value_ptr.*)).destroy();
         }
 
         self.caches.deinit();
@@ -28,7 +28,7 @@ pub const Assets = struct {
             return @as(*Cache(AssetT), @ptrFromInt(tid));
         }
 
-        const cache = Cache(AssetT).initPtr(self.allocator);
+        const cache = Cache(AssetT).create(self.allocator);
         _ = self.caches.put(utils.typeId(AssetT), @intFromPtr(cache)) catch unreachable;
         return cache;
     }

--- a/src/signals/dispatcher.zig
+++ b/src/signals/dispatcher.zig
@@ -20,7 +20,7 @@ pub const Dispatcher = struct {
         while (iter.next()) |ptr| {
             // HACK: we dont know the Type here but we need to call deinit
             var signal = @as(*Signal(.{}), @ptrFromInt(ptr.value_ptr.*));
-            signal.deinit();
+            signal.destroy();
         }
 
         self.signals.deinit();

--- a/src/signals/sink.zig
+++ b/src/signals/sink.zig
@@ -48,14 +48,14 @@ pub fn SinkFromTuple(comptime Params: type) type {
         /// NOTE: each free_fn can only be connected ONCE to the same sink
         pub fn connect(self: Self, free_fn: Delegate(Params).FreeFn) void {
             std.debug.assert(self.indexOf(free_fn) == null);
-            _ = owning_signal.calls.insert(self.insert_index, Delegate(Params).initFree(free_fn)) catch unreachable;
+            _ = owning_signal.calls.insert(owning_signal.allocator, self.insert_index, Delegate(Params).initFree(free_fn)) catch unreachable;
         }
 
         /// connects a context `Delegate(Params).BindFn(@TypeOf(ctx_ptr))` to this sink
         /// NOTE: each ctx_ptr can only be connected ONCE to the same sink
         pub fn connectBound(self: Self, ctx_ptr: anytype, bind_fn: Delegate(Params).BindFn(@TypeOf(ctx_ptr))) void {
             std.debug.assert(self.indexOfBound(ctx_ptr) == null);
-            _ = owning_signal.calls.insert(self.insert_index, Delegate(Params).initBind(ctx_ptr, bind_fn)) catch unreachable;
+            _ = owning_signal.calls.insert(owning_signal.allocator, self.insert_index, Delegate(Params).initBind(ctx_ptr, bind_fn)) catch unreachable;
         }
 
         pub fn disconnect(self: Self, free_fn: Delegate(Params).FreeFn) void {


### PR DESCRIPTION
* Use `ArrayListUnmanaged` and `HashMapUnmanaged` to avoid unnecessary allocation copies.
* Refactor the `initPtr()` methods into a `create/destroy` pair. This allows us to replace unused `?Allocator` optional with `Allocator` struct and remove duplicated initialization code.