### PR TITLE
Remove usingnamespace

### DIFF
--- a/examples/empty.zig
+++ b/examples/empty.zig
@@ -7,6 +7,9 @@ pub const EntityTraits = ecs.EntityTraitsType(.medium);
 pub const Empty = struct {};
 pub const Velocity = struct { x: f32, y: f32 };
 pub const Position = struct { x: f32, y: f32 };
+pub const EmptyB = struct {};
+
+const total_entities: usize = 10000;
 
 /// logs the timing for views vs non-owning groups vs owning groups with 1,000,000 entities
 pub fn main() !void {
@@ -17,4 +20,33 @@ pub fn main() !void {
     reg.addOrReplace(empty, Empty{});
     _ = reg.fetchRemove(Empty, empty);
     _ = reg.fetchReplace(empty, Empty{});
+
+    createEntities(&reg);
+    owningGroup(&reg);
+}
+
+fn createEntities(reg: *ecs.Registry) void {
+    var r = std.Random.DefaultPrng.init(666);
+
+    var i: usize = 0;
+    while (i < total_entities) : (i += 1) {
+        const e1 = reg.create();
+        reg.add(e1, Empty{});
+        reg.add(e1, Position{ .x = 1, .y = r.random().float(f32) * 100 });
+        reg.add(e1, Velocity{ .x = 1, .y = r.random().float(f32) * 100 });
+        reg.add(e1, EmptyB{});
+    }
+}
+
+fn owningGroup(reg: *ecs.Registry) void {
+    var group = reg.group(.{ Empty, Velocity, Position, EmptyB }, .{}, .{});
+
+    const SortContext = struct {
+        fn sort(_: void, a: Position, b: Position) bool {
+            return a.y < b.y;
+        }
+    };
+
+    group.sort(Position, {}, SortContext.sort);
+    group.sort(Position, {}, SortContext.sort);
 }

--- a/examples/group_sort.zig
+++ b/examples/group_sort.zig
@@ -4,7 +4,6 @@ const ecs = @import("ecs");
 // override the EntityTraits used by ecs
 pub const EntityTraits = ecs.EntityTraitsType(.medium);
 
-pub const EmptyStruct = struct {};
 pub const Velocity = struct { x: f32, y: f32 };
 pub const Position = struct { x: f32, y: f32 };
 
@@ -28,7 +27,6 @@ fn createEntities(reg: *ecs.Registry) void {
         const e1 = reg.create();
         reg.add(e1, Position{ .x = 1, .y = r.random().float(f32) * 100 });
         reg.add(e1, Velocity{ .x = 1, .y = r.random().float(f32) * 100 });
-        reg.add(e1, EmptyStruct{});
     }
 
     const end = timer.lap();
@@ -36,7 +34,7 @@ fn createEntities(reg: *ecs.Registry) void {
 }
 
 fn owningGroup(reg: *ecs.Registry) void {
-    var group = reg.group(.{ EmptyStruct, Velocity, Position }, .{}, .{});
+    var group = reg.group(.{ Velocity, Position }, .{}, .{});
 
     // var group_iter = group.iterator(struct { vel: *Velocity, pos: *Position });
     // while (group_iter.next()) |e| {
@@ -64,3 +62,4 @@ fn owningGroup(reg: *ecs.Registry) void {
     //     std.debug.print("pos.y {d:.3}, ent: {}\n", .{e.pos.y, group_iter2.entity()});
     // }
 }
+

--- a/examples/group_sort.zig
+++ b/examples/group_sort.zig
@@ -4,6 +4,7 @@ const ecs = @import("ecs");
 // override the EntityTraits used by ecs
 pub const EntityTraits = ecs.EntityTraitsType(.medium);
 
+pub const EmptyStruct = struct {};
 pub const Velocity = struct { x: f32, y: f32 };
 pub const Position = struct { x: f32, y: f32 };
 
@@ -27,6 +28,7 @@ fn createEntities(reg: *ecs.Registry) void {
         const e1 = reg.create();
         reg.add(e1, Position{ .x = 1, .y = r.random().float(f32) * 100 });
         reg.add(e1, Velocity{ .x = 1, .y = r.random().float(f32) * 100 });
+        reg.add(e1, EmptyStruct{});
     }
 
     const end = timer.lap();
@@ -34,7 +36,7 @@ fn createEntities(reg: *ecs.Registry) void {
 }
 
 fn owningGroup(reg: *ecs.Registry) void {
-    var group = reg.group(.{ Velocity, Position }, .{}, .{});
+    var group = reg.group(.{ EmptyStruct, Velocity, Position }, .{}, .{});
 
     // var group_iter = group.iterator(struct { vel: *Velocity, pos: *Position });
     // while (group_iter.next()) |e| {

--- a/src/ecs.zig
+++ b/src/ecs.zig
@@ -1,9 +1,6 @@
 // ecs
 pub const EntityTraitsType = @import("ecs/entity.zig").EntityTraitsType;
 
-// TODO: remove me. this is just for testing
-pub const ComponentStorage = @import("ecs/component_storage.zig").ComponentStorage;
-
 pub const Entity = @import("ecs/registry.zig").Entity;
 pub const Registry = @import("ecs/registry.zig").Registry;
 pub const EntityHandles = @import("ecs/registry.zig").EntityHandles;

--- a/src/ecs/component_storage.zig
+++ b/src/ecs/component_storage.zig
@@ -153,86 +153,100 @@ pub fn ComponentStorage(comptime Component: type, comptime Entity: type) type {
             return self.set.len();
         }
 
-        pub usingnamespace if (is_empty_struct)
-            struct {
-                /// Sort Entities according to the given comparison function. Only T == Entity is allowed. The constraint param only exists for
-                /// parity with non-empty Components
-                pub fn sort(self: Self, comptime T: type, context: anytype, comptime lessThan: *const fn (@TypeOf(context), T, T) bool) void {
-                    std.debug.assert(T == Entity);
-                    self.set.sort(context, lessThan);
-                }
+        /// Direct access to the array of objects
+        pub fn raw(self: Self) []Component {
+            if (is_empty_struct) {
+                @compileError(std.fmt.comptimePrint("Shouldn't call {} with empty components", .{@src().fn_name}));
             }
-        else
-            struct {
-                /// Direct access to the array of objects
-                pub fn raw(self: Self) []Component {
-                    return self.instances.items;
-                }
+            return self.instances.items;
+        }
 
-                /// Replaces the given component for an entity
-                pub fn replace(self: *Self, entity: Entity, value: Component) void {
-                    self.get(entity).* = value;
-                    self.update.publish(.{ self.registry, entity });
-                }
+        /// Replaces the given component for an entity
+        pub fn replace(self: *Self, entity: Entity, value: Component) void {
+            if (is_empty_struct) {
+                @compileError(std.fmt.comptimePrint("Shouldn't call {} with empty components", .{@src().fn_name}));
+            }
+            self.get(entity).* = value;
+            self.update.publish(.{ self.registry, entity });
+        }
 
-                /// Returns the object associated with an entity
-                pub fn get(self: *Self, entity: Entity) *Component {
-                    std.debug.assert(self.contains(entity));
-                    return &self.instances.items[self.set.index(entity)];
-                }
+        /// Returns the object associated with an entity
+        pub fn get(self: *Self, entity: Entity) *Component {
+            if (is_empty_struct) {
+                @compileError(std.fmt.comptimePrint("Shouldn't call {} with empty components", .{@src().fn_name}));
+            }
+            std.debug.assert(self.contains(entity));
+            return &self.instances.items[self.set.index(entity)];
+        }
 
-                pub fn getConst(self: *Self, entity: Entity) Component {
-                    return self.instances.items[self.set.index(entity)];
-                }
+        pub fn getConst(self: *Self, entity: Entity) Component {
+            if (is_empty_struct) {
+                @compileError(std.fmt.comptimePrint("Shouldn't call {} with empty components", .{@src().fn_name}));
+            }
+            return self.instances.items[self.set.index(entity)];
+        }
 
-                /// Returns a pointer to the object associated with an entity, if any.
-                pub fn tryGet(self: *Self, entity: Entity) ?*Component {
-                    return if (self.set.contains(entity)) &self.instances.items[self.set.index(entity)] else null;
-                }
+        /// Returns a pointer to the object associated with an entity, if any.
+        pub fn tryGet(self: *Self, entity: Entity) ?*Component {
+            if (is_empty_struct) {
+                @compileError(std.fmt.comptimePrint("Shouldn't call {} with empty components", .{@src().fn_name}));
+            }
+            return if (self.set.contains(entity)) &self.instances.items[self.set.index(entity)] else null;
+        }
 
-                pub fn tryGetConst(self: *Self, entity: Entity) ?Component {
-                    return if (self.set.contains(entity)) self.instances.items[self.set.index(entity)] else null;
-                }
+        pub fn tryGetConst(self: *Self, entity: Entity) ?Component {
+            if (is_empty_struct) {
+                @compileError(std.fmt.comptimePrint("Shouldn't call {} with empty components", .{@src().fn_name}));
+            }
+            return if (self.set.contains(entity)) self.instances.items[self.set.index(entity)] else null;
+        }
 
-                /// Sort Entities or Components according to the given comparison function. Valid types for T are Entity or Component.
-                pub fn sort(self: *Self, comptime T: type, length: usize, context: anytype, comptime lessThan: *const fn (@TypeOf(context), T, T) bool) void {
-                    std.debug.assert(T == Entity or T == Component);
+        pub fn sortEmpty(self: Self, comptime T: type, context: anytype, comptime lessThan: *const fn (@TypeOf(context), T, T) bool) void {
+            std.debug.assert(T == Entity);
+            self.set.sort(context, lessThan);
+        }
 
-                    // we have to perform a swap after the sort for all moved entities so we make a helper struct for that. In the
-                    // case of a Component sort we also wrap that into the struct so we can get the Component data to pass to the
-                    // lessThan method passed in.
-                    if (T == Entity) {
-                        const SortContext = struct {
-                            storage: *Self,
+        /// Sort Entities or Components according to the given comparison function. Valid types for T are Entity or Component.
+        pub fn sort(self: *Self, comptime T: type, length: usize, context: anytype, comptime lessThan: *const fn (@TypeOf(context), T, T) bool) void {
+            if (is_empty_struct) {
+                @compileError(std.fmt.comptimePrint("Empty components shouldn't call {}", .{@src().fn_name}));
+            }
+            std.debug.assert(T == Entity or T == Component);
 
-                            pub fn swap(this: @This(), a: Entity, b: Entity) void {
-                                this.storage.safeSwap(this.storage, a, b, true);
-                            }
-                        };
-                        const swap_context = SortContext{ .storage = self };
-                        self.set.arrange(length, context, lessThan, swap_context);
-                    } else {
-                        const SortContext = struct {
-                            storage: *Self,
-                            wrapped_context: @TypeOf(context),
-                            lessThan: *const fn (@TypeOf(context), T, T) bool,
+            // we have to perform a swap after the sort for all moved entities so we make a helper struct for that. In the
+            // case of a Component sort we also wrap that into the struct so we can get the Component data to pass to the
+            // lessThan method passed in.
+            if (T == Entity) {
+                const SortContext = struct {
+                    storage: *Self,
 
-                            fn sort(this: @This(), a: Entity, b: Entity) bool {
-                                const real_a = this.storage.getConst(a);
-                                const real_b = this.storage.getConst(b);
-                                return this.lessThan(this.wrapped_context, real_a, real_b);
-                            }
-
-                            pub fn swap(this: @This(), a: Entity, b: Entity) void {
-                                this.storage.safeSwap(this.storage, a, b, true);
-                            }
-                        };
-
-                        const swap_context = SortContext{ .storage = self, .wrapped_context = context, .lessThan = lessThan };
-                        self.set.arrange(length, swap_context, SortContext.sort, swap_context);
+                    pub fn swap(this: @This(), a: Entity, b: Entity) void {
+                        this.storage.safeSwap(this.storage, a, b, true);
                     }
-                }
-            };
+                };
+                const swap_context = SortContext{ .storage = self };
+                self.set.arrange(length, context, lessThan, swap_context);
+            } else {
+                const SortContext = struct {
+                    storage: *Self,
+                    wrapped_context: @TypeOf(context),
+                    lessThan: *const fn (@TypeOf(context), T, T) bool,
+
+                    fn sort(this: @This(), a: Entity, b: Entity) bool {
+                        const real_a = this.storage.getConst(a);
+                        const real_b = this.storage.getConst(b);
+                        return this.lessThan(this.wrapped_context, real_a, real_b);
+                    }
+
+                    pub fn swap(this: @This(), a: Entity, b: Entity) void {
+                        this.storage.safeSwap(this.storage, a, b, true);
+                    }
+                };
+
+                const swap_context = SortContext{ .storage = self, .wrapped_context = context, .lessThan = lessThan };
+                self.set.arrange(length, swap_context, SortContext.sort, swap_context);
+            }
+        }
 
         /// Direct access to the array of entities
         pub fn data(self: Self) []const Entity {
@@ -361,13 +375,13 @@ test "sort empty component" {
     store.add(0, Empty{});
 
     const asc_u32 = comptime std.sort.asc(u32);
-    store.sort(u32, {}, asc_u32);
+    store.sortEmpty(u32, {}, asc_u32);
     for (store.data(), 0..) |e, i| {
         try std.testing.expectEqual(@as(u32, @intCast(i)), e);
     }
 
     const desc_u32 = comptime std.sort.desc(u32);
-    store.sort(u32, {}, desc_u32);
+    store.sortEmpty(u32, {}, desc_u32);
     var counter: u32 = 2;
     for (store.data()) |e| {
         try std.testing.expectEqual(counter, e);

--- a/src/ecs/component_storage.zig
+++ b/src/ecs/component_storage.zig
@@ -155,49 +155,31 @@ pub fn ComponentStorage(comptime Component: type, comptime Entity: type) type {
 
         /// Direct access to the array of objects
         pub fn raw(self: Self) []Component {
-            if (is_empty_struct) {
-                @compileError(std.fmt.comptimePrint("Shouldn't call {} with empty components", .{@src().fn_name}));
-            }
             return self.instances.items;
         }
 
         /// Replaces the given component for an entity
         pub fn replace(self: *Self, entity: Entity, value: Component) void {
-            if (is_empty_struct) {
-                @compileError(std.fmt.comptimePrint("Shouldn't call {} with empty components", .{@src().fn_name}));
-            }
             self.get(entity).* = value;
             self.update.publish(.{ self.registry, entity });
         }
 
         /// Returns the object associated with an entity
         pub fn get(self: *Self, entity: Entity) *Component {
-            if (is_empty_struct) {
-                @compileError(std.fmt.comptimePrint("Shouldn't call {} with empty components", .{@src().fn_name}));
-            }
             std.debug.assert(self.contains(entity));
             return &self.instances.items[self.set.index(entity)];
         }
 
         pub fn getConst(self: *Self, entity: Entity) Component {
-            if (is_empty_struct) {
-                @compileError(std.fmt.comptimePrint("Shouldn't call {} with empty components", .{@src().fn_name}));
-            }
             return self.instances.items[self.set.index(entity)];
         }
 
         /// Returns a pointer to the object associated with an entity, if any.
         pub fn tryGet(self: *Self, entity: Entity) ?*Component {
-            if (is_empty_struct) {
-                @compileError(std.fmt.comptimePrint("Shouldn't call {} with empty components", .{@src().fn_name}));
-            }
             return if (self.set.contains(entity)) &self.instances.items[self.set.index(entity)] else null;
         }
 
         pub fn tryGetConst(self: *Self, entity: Entity) ?Component {
-            if (is_empty_struct) {
-                @compileError(std.fmt.comptimePrint("Shouldn't call {} with empty components", .{@src().fn_name}));
-            }
             return if (self.set.contains(entity)) self.instances.items[self.set.index(entity)] else null;
         }
 
@@ -208,9 +190,6 @@ pub fn ComponentStorage(comptime Component: type, comptime Entity: type) type {
 
         /// Sort Entities or Components according to the given comparison function. Valid types for T are Entity or Component.
         pub fn sort(self: *Self, comptime T: type, length: usize, context: anytype, comptime lessThan: *const fn (@TypeOf(context), T, T) bool) void {
-            if (is_empty_struct) {
-                @compileError(std.fmt.comptimePrint("Empty components shouldn't call {}", .{@src().fn_name}));
-            }
             std.debug.assert(T == Entity or T == Component);
 
             // we have to perform a swap after the sort for all moved entities so we make a helper struct for that. In the


### PR DESCRIPTION
closes #59 

Since the sort for empty components already had a different signature, I just changed the name.

There is no need to check if the component is empty inside the other changed functions: `component_storage.zig` is now only internal (this doesn't affect testing) and everything is checked properly in the public API (because of #53 )