### PR TITLE
extend view

### DIFF
--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -547,7 +547,7 @@ pub const Registry = struct {
             excludes_arr[i] = utils.typeId(t);
         }
 
-        return MultiView(includes.len, excludes.len).init(self, includes_arr, excludes_arr);
+        return MultiView(includes.len, excludes.len, includes, excludes).init(self);
     }
 
     pub fn basicView(self: *Registry, comptime Component: anytype) BasicView(Component) {
@@ -563,7 +563,7 @@ pub const Registry = struct {
     /// returns the Type that a view will be based on the includes and excludes
     fn ViewType(comptime includes: anytype, comptime excludes: anytype) type {
         if (includes.len == 1 and excludes.len == 0) return BasicView(includes[0]);
-        return MultiView(includes.len, excludes.len);
+        return MultiView(includes.len, excludes.len, includes, excludes);
     }
 
     /// creates an optimized group for iterating components

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -527,27 +527,15 @@ pub const Registry = struct {
     }
 
     pub fn view(self: *Registry, comptime includes: anytype, comptime excludes: anytype) ViewType(includes, excludes) {
-        std.debug.assert(@typeInfo(@TypeOf(includes)) == .@"struct");
-        std.debug.assert(@typeInfo(@TypeOf(excludes)) == .@"struct");
-        std.debug.assert(includes.len > 0);
+        if (comptime @typeInfo(@TypeOf(includes)) != .@"struct") @compileError("'includes' argument must be a tuple");
+        if (comptime @typeInfo(@TypeOf(excludes)) != .@"struct") @compileError("'excludes' argument must be a tuple");
+        if (comptime includes.len < 1) @compileError("'includes' must have at least one element");
 
         // just one include so use the optimized BasicView
         if (includes.len == 1 and excludes.len == 0)
             return BasicView(includes[0]).init(self.assure(includes[0]));
 
-        var includes_arr: [includes.len]u32 = undefined;
-        inline for (includes, 0..) |t, i| {
-            _ = self.assure(t);
-            includes_arr[i] = utils.typeId(t);
-        }
-
-        var excludes_arr: [excludes.len]u32 = undefined;
-        inline for (excludes, 0..) |t, i| {
-            _ = self.assure(t);
-            excludes_arr[i] = utils.typeId(t);
-        }
-
-        return MultiView(includes.len, excludes.len, includes, excludes).init(self);
+        return MultiView(includes, excludes).init(self);
     }
 
     pub fn basicView(self: *Registry, comptime Component: anytype) BasicView(Component) {
@@ -563,7 +551,7 @@ pub const Registry = struct {
     /// returns the Type that a view will be based on the includes and excludes
     fn ViewType(comptime includes: anytype, comptime excludes: anytype) type {
         if (includes.len == 1 and excludes.len == 0) return BasicView(includes[0]);
-        return MultiView(includes.len, excludes.len, includes, excludes);
+        return MultiView(includes, excludes);
     }
 
     /// creates an optimized group for iterating components

--- a/src/ecs/utils.zig
+++ b/src/ecs/utils.zig
@@ -147,15 +147,6 @@ pub fn isComptime(comptime T: type) bool {
     };
 }
 
-pub fn getTypeSequenceNumberOfCharacters(comptime types: anytype) usize {
-    @setEvalBranchQuota(1000 * types.len);
-    var sum = 0;
-    inline for (types) |t| {
-        sum += @typeName(t).len;
-    }
-    return sum;
-}
-
 test "ReverseSliceIterator" {
     const slice = std.testing.allocator.alloc(usize, 10) catch unreachable;
     defer std.testing.allocator.free(slice);

--- a/src/ecs/utils.zig
+++ b/src/ecs/utils.zig
@@ -147,6 +147,15 @@ pub fn isComptime(comptime T: type) bool {
     };
 }
 
+pub fn getTypeSequenceNumberOfCharacters(comptime types: anytype) usize {
+    @setEvalBranchQuota(1000 * types.len);
+    var sum = 0;
+    inline for (types) |t| {
+        sum += @typeName(t).len;
+    }
+    return sum;
+}
+
 test "ReverseSliceIterator" {
     const slice = std.testing.allocator.alloc(usize, 10) catch unreachable;
     defer std.testing.allocator.free(slice);

--- a/src/ecs/views.zig
+++ b/src/ecs/views.zig
@@ -165,16 +165,22 @@ pub fn MultiView(comptime n_includes: usize, comptime n_excludes: usize) type {
             return MultiView(new_n_includes, new_n_excludes);
         }
 
+        /// Merge views, resulting in a new one.
+        /// There must no component overlap between the views.
         pub fn extendNonOverlapping(self: *Self, multiview: anytype) ExtendNonOverlappingReturnType(@TypeOf(self.*), @TypeOf(multiview)) {
             const new_n_includes = n_includes + ArrayAttributeLength(@TypeOf(multiview), .type_ids);
             const new_n_excludes = n_excludes + ArrayAttributeLength(@TypeOf(multiview), .exclude_type_ids);
 
             if (comptime new_n_includes != n_includes) {
+                // views can't share components
                 std.debug.assert(null == std.mem.indexOf(u32, &self.type_ids, &multiview.type_ids));
+                // views can't share components
                 std.debug.assert(null == std.mem.indexOf(u32, &self.exclude_type_ids, &multiview.type_ids));
             }
             if (comptime new_n_excludes != n_excludes) {
+                // views can't share components
                 std.debug.assert(null == std.mem.indexOf(u32, &self.type_ids, &multiview.exclude_type_ids));
+                // views can't share components
                 std.debug.assert(null == std.mem.indexOf(u32, &self.exclude_type_ids, &multiview.exclude_type_ids));
             }
 
@@ -193,11 +199,15 @@ pub fn MultiView(comptime n_includes: usize, comptime n_excludes: usize) type {
             );
         }
 
+        /// Create a new view where the given component is included.
+        /// The component must not already be included or excluded from the view.
         pub fn include(self: *Self, comptime T: type) MultiView(n_includes + 1, n_excludes) {
             const multiview = MultiView(1, 0).init(self.registry, .{utils.typeId(T)}, .{});
             return self.extendNonOverlapping(multiview);
         }
 
+        /// Create a new view where the given type is excluded.
+        /// The component must not already be included or excluded from the view.
         pub fn exclude(self: *Self, comptime T: type) MultiView(n_includes, n_excludes + 1) {
             const multiview = MultiView(0, 1).init(self.registry, .{}, .{utils.typeId(T)});
             return self.extendNonOverlapping(multiview);

--- a/src/ecs/views.zig
+++ b/src/ecs/views.zig
@@ -58,26 +58,29 @@ pub fn BasicView(comptime T: type) type {
     };
 }
 
-pub fn MultiView(comptime n_includes: usize, comptime n_excludes: usize, comptime includes: [n_includes]type, comptime excludes: [n_excludes]type) type {
+pub fn MultiView(comptime n_includes: usize, comptime n_excludes: usize, comptime _includes: [n_includes]type, comptime _excludes: [n_excludes]type) type {
     if (n_includes == 0) {
         @compileError("n_includes must be at least 1 for any view");
     }
     const include_type_ids = include_type_ids: {
         var ids: [n_includes]u32 = undefined;
-        for (includes, 0..) |t, i| {
+        for (_includes, 0..) |t, i| {
             ids[i] = utils.typeId(t);
         }
         break :include_type_ids ids;
     };
     const exclude_type_ids = exclude_type_ids: {
         var ids: [n_excludes]u32 = undefined;
-        for (excludes, 0..) |t, i| {
+        for (_excludes, 0..) |t, i| {
             ids[i] = utils.typeId(t);
         }
         break :exclude_type_ids ids;
     };
     return struct {
         const Self = @This();
+
+        comptime includes: @TypeOf(_includes) = _includes,
+        comptime excludes: @TypeOf(_excludes) = _excludes,
 
         registry: *Registry,
         order: [n_includes]u32,
@@ -172,12 +175,6 @@ pub fn MultiView(comptime n_includes: usize, comptime n_excludes: usize, comptim
             }
             const field_type_info = @typeInfo(std.meta.fieldInfo(T, field).type);
             return field_type_info.array.len;
-        }
-
-        fn ExtendNonOverlappingReturnType(comptime view1_type: type, comptime view2_type: type) type {
-            const new_n_includes = ArrayAttributeLength(view1_type, .type_ids) + ArrayAttributeLength(view2_type, .type_ids);
-            const new_n_excludes = ArrayAttributeLength(view1_type, .exclude_type_ids) + ArrayAttributeLength(view2_type, .exclude_type_ids);
-            return MultiView(new_n_includes, new_n_excludes);
         }
     };
 }


### PR DESCRIPTION
Adds `include`, `exclude` and `extendNonOverlapping` methods to `MultiView`. Tried to implement a non-overlapping version but since `MultiView` doesn't carry information about included and excluded types at comptime (only how many), I don't really see a way to do this without a significant rewrite.