### PR TITLE
Fix raw and data

### DIFF
--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -251,7 +251,7 @@ pub const Registry = struct {
 
     /// Direct access to the list of entities of a given pool
     pub fn data(self: *Registry, comptime T: type) []Entity {
-        return self.assure(T).data().*;
+        return self.assure(T).dataPtr().*;
     }
 
     pub fn valid(self: *Registry, entity: Entity) bool {

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -245,12 +245,12 @@ pub const Registry = struct {
     }
 
     /// Direct access to the list of components of a given pool
-    pub fn raw(self: Registry, comptime T: type) []T {
+    pub fn raw(self: *Registry, comptime T: type) []T {
         return self.assure(T).raw();
     }
 
     /// Direct access to the list of entities of a given pool
-    pub fn data(self: Registry, comptime T: type) []Entity {
+    pub fn data(self: *Registry, comptime T: type) []Entity {
         return self.assure(T).data().*;
     }
 


### PR DESCRIPTION
This PR fixes the `raw` (returns component data) and `data` (returns entities) methods from `registry.zig`. Both methods used a value of `Registry` instead of a pointer, which is what `assure` expects (and `assure` is called by both). Also, the `data` method called the storage's `data` method, which returned an incompatible type (was not a const `Entity`). Taking into account the deference, I assume the intention was actually to call `dataPtr` (which just makes sense, `Entity`s should be `const`, why would we want to change one through the public API?)