### PR TITLE
Turn entity into a packed struct

### DIFF
--- a/examples/empty.zig
+++ b/examples/empty.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const ecs = @import("ecs");
 
 // override the EntityTraits used by ecs
-pub const EntityTraits = ecs.EntityTraitsType(.medium);
+pub const Entity = ecs.EntityClass(.medium);
 
 pub const Empty = struct {};
 pub const Velocity = struct { x: f32, y: f32 };

--- a/examples/group_sort.zig
+++ b/examples/group_sort.zig
@@ -62,4 +62,3 @@ fn owningGroup(reg: *ecs.Registry) void {
     //     std.debug.print("pos.y {d:.3}, ent: {}\n", .{e.pos.y, group_iter2.entity()});
     // }
 }
-

--- a/src/ecs.zig
+++ b/src/ecs.zig
@@ -1,6 +1,5 @@
 // ecs
-pub const EntityTraitsType = @import("ecs/entity.zig").EntityTraitsType;
-
+pub const EntityClass = @import("ecs/entity.zig").EntityClass;
 pub const Entity = @import("ecs/registry.zig").Entity;
 pub const Registry = @import("ecs/registry.zig").Registry;
 pub const EntityHandles = @import("ecs/registry.zig").EntityHandles;

--- a/src/ecs/entity.zig
+++ b/src/ecs/entity.zig
@@ -1,56 +1,38 @@
 const std = @import("std");
 
-/// default EntityTraitsDefinition with reasonable sizes suitable for most situations
-pub const EntityTraits = EntityTraitsType(.medium);
+/// default Entity with reasonable sizes suitable for most situations
+pub const DefaultEntity = EntityClass(.medium);
 
-pub const EntityTraitsSize = enum { small, medium, large };
+pub const EntityParameters = struct {
+    total_bits: usize,
+    index_bits: usize,
+    version_bits: usize,
+    pub const small: @This() = .{ .total_bits = 16, .index_bits = 12, .version_bits = 4 };
+    pub const medium: @This() = .{ .total_bits = 32, .index_bits = 20, .version_bits = 12 };
+    pub const large: @This() = .{ .total_bits = 64, .index_bits = 32, .version_bits = 32 };
+};
 
-pub fn EntityTraitsType(comptime size: EntityTraitsSize) type {
-    return switch (size) {
-        .small => EntityTraitsDefinition(u16, u12, u4),
-        .medium => EntityTraitsDefinition(u32, u20, u12),
-        .large => EntityTraitsDefinition(u64, u32, u32),
+pub fn EntityClass(comptime entity_parameters: EntityParameters) type {
+    if (entity_parameters.index_bits + entity_parameters.version_bits != entity_parameters.total_bits)
+        @compileError("index_size and version_size must sum to entity_size");
+
+    const EntityBackingInt = std.meta.Int(.unsigned, entity_parameters.total_bits);
+
+    return packed struct(EntityBackingInt) {
+        pub const Index = std.meta.Int(.unsigned, entity_parameters.index_bits);
+        pub const Version = std.meta.Int(.unsigned, entity_parameters.version_bits);
+
+        index: Index,
+        version: Version,
     };
 }
 
-fn EntityTraitsDefinition(comptime EntityType: type, comptime IndexType: type, comptime VersionType: type) type {
-    std.debug.assert(std.meta.Int(.unsigned, @bitSizeOf(EntityType)) == EntityType);
-    std.debug.assert(std.meta.Int(.unsigned, @bitSizeOf(IndexType)) == IndexType);
-    std.debug.assert(std.meta.Int(.unsigned, @bitSizeOf(VersionType)) == VersionType);
+test EntityClass {
+    const Small = EntityClass(.small);
+    const Medium = EntityClass(.medium);
+    const Large = EntityClass(.large);
 
-    const sizeOfIndexType = @bitSizeOf(IndexType);
-    const sizeOfVersionType = @bitSizeOf(VersionType);
-    const entityShift = sizeOfIndexType;
-
-    if (sizeOfIndexType + sizeOfVersionType != @bitSizeOf(EntityType))
-        @compileError("IndexType and VersionType must sum to EntityType's bit count");
-
-    const entityMask = std.math.maxInt(IndexType);
-    const versionMask = std.math.maxInt(VersionType);
-
-    return struct {
-        entity_type: type = EntityType,
-        index_type: type = IndexType,
-        version_type: type = VersionType,
-        /// Mask to use to get the entity index number out of an identifier
-        entity_mask: EntityType = entityMask,
-        /// Mask to use to get the version out of an identifier
-        version_mask: EntityType = versionMask,
-        /// Bit size of entity in entity_type
-        entity_shift: EntityType = entityShift,
-
-        pub fn init() @This() {
-            return @This(){};
-        }
-    };
-}
-
-test "entity traits" {
-    const sm = EntityTraitsType(.small).init();
-    const m = EntityTraitsType(.medium).init();
-    const l = EntityTraitsType(.large).init();
-
-    try std.testing.expectEqual(sm.entity_mask, std.math.maxInt(sm.index_type));
-    try std.testing.expectEqual(m.entity_mask, std.math.maxInt(m.index_type));
-    try std.testing.expectEqual(l.entity_mask, std.math.maxInt(l.index_type));
+    try std.testing.expectEqual(Small.Index, u12);
+    try std.testing.expectEqual(Medium.Index, u20);
+    try std.testing.expectEqual(Large.Index, u32);
 }

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -262,7 +262,7 @@ pub const Registry = struct {
 
     /// Creates a new entity and returns it
     pub fn create(self: *Registry) Entity {
-        return self.handles.create();
+        return self.handles.create() catch unreachable;
     }
 
     /// Destroys an entity

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -11,11 +11,10 @@ const TypeStore = @import("type_store.zig").TypeStore;
 
 // allow overriding EntityTraits by setting in root via: EntityTraits = EntityTraitsType(.medium);
 const root = @import("root");
-pub const entity_traits = if (@hasDecl(root, "EntityTraits")) root.EntityTraits.init() else @import("entity.zig").EntityTraits.init();
+pub const Entity = if (@hasDecl(root, "Entity")) root.Entity else @import("entity.zig").DefaultEntity;
 
 // setup the Handles type based on the type set in EntityTraits
-pub const EntityHandles = Handles(entity_traits.entity_type, entity_traits.index_type, entity_traits.version_type);
-pub const Entity = entity_traits.entity_type;
+pub const EntityHandles = Handles(Entity);
 
 const BasicView = @import("views.zig").BasicView;
 const MultiView = @import("views.zig").MultiView;
@@ -259,16 +258,6 @@ pub const Registry = struct {
 
     pub fn valid(self: *Registry, entity: Entity) bool {
         return self.handles.alive(entity);
-    }
-
-    /// Returns the entity identifier without the version
-    pub fn entityId(_: Registry, entity: Entity) Entity {
-        return entity & entity_traits.entity_mask;
-    }
-
-    /// Returns the version stored along with an entity identifier
-    pub fn version(_: *Registry, entity: Entity) entity_traits.version_type {
-        return @truncate(entity >> entity_traits.entity_shift);
     }
 
     /// Creates a new entity and returns it

--- a/src/ecs/sparse_set.zig
+++ b/src/ecs/sparse_set.zig
@@ -27,17 +27,20 @@ fn std_sort_insertionSort_clone(
     }
 }
 
-// TODO: fix entity_mask. it should come from EntityTraitsDefinition.
-pub fn SparseSet(comptime SparseT: type) type {
+pub fn SparseSet(comptime Entity: type) type {
     return struct {
         const Self = @This();
+
+        // TODO: should we support configurable or runtime page sizes?
         const page_size: usize = 4096;
 
-        sparse: std.ArrayListUnmanaged(?[]SparseT),
-        dense: std.ArrayListUnmanaged(SparseT),
-        entity_mask: SparseT,
+        /// stores an index into `dense`
+        sparse: std.ArrayListUnmanaged(?*[page_size]Entity.Index),
+        dense: std.ArrayListUnmanaged(Entity),
 
         allocator: std.mem.Allocator,
+
+        const tombstone = std.math.maxInt(Entity.Index);
 
         pub fn create(allocator: std.mem.Allocator) *Self {
             const set = allocator.create(Self) catch unreachable;
@@ -52,18 +55,19 @@ pub fn SparseSet(comptime SparseT: type) type {
         }
 
         pub fn init(allocator: std.mem.Allocator) Self {
-            return Self{
-                .sparse = std.ArrayListUnmanaged(?[]SparseT){},
-                .dense = std.ArrayListUnmanaged(SparseT){},
-                .entity_mask = registry.entity_traits.entity_mask,
+            return .{
+                .sparse = .empty,
+                .dense = .empty,
                 .allocator = allocator,
             };
         }
 
         pub fn deinit(self: *Self) void {
-            for (self.sparse.items) |array| {
-                if (array) |arr| {
-                    self.allocator.free(arr);
+            self.detectCorruption();
+
+            for (self.sparse.items) |maybe_page| {
+                if (maybe_page) |page| {
+                    self.allocator.free(page);
                 }
             }
 
@@ -71,30 +75,33 @@ pub fn SparseSet(comptime SparseT: type) type {
             self.sparse.deinit(self.allocator);
         }
 
-        pub fn page(self: Self, sparse: SparseT) usize {
-            return (sparse & self.entity_mask) / page_size;
+        /// Computes the page of an entity, given as an index
+        pub fn pageIndex(_: Self, entity: Entity) usize {
+            return entity.index / page_size;
         }
 
-        fn offset(_: Self, sparse: SparseT) usize {
-            return sparse & (page_size - 1);
+        /// Computes an entity's offset within its page
+        fn pageOffset(_: Self, entity: Entity) usize {
+            return entity.index & (page_size - 1);
         }
 
-        fn assure(self: *Self, pos: usize) []SparseT {
-            if (pos >= self.sparse.items.len) {
+        fn getOrCreatePage(self: *Self, page_index: usize) *[page_size]Entity.Index {
+            // Allocate references to new pages if necessary
+            if (page_index >= self.sparse.items.len) {
                 const start_pos = self.sparse.items.len;
-                self.sparse.resize(self.allocator, pos + 1) catch unreachable;
+                self.sparse.resize(self.allocator, page_index + 1) catch unreachable;
                 self.sparse.expandToCapacity();
-
                 @memset(self.sparse.items[start_pos..], null);
             }
 
-            if (self.sparse.items[pos] == null) {
-                const new_page = self.allocator.alloc(SparseT, page_size) catch unreachable;
-                @memset(new_page, std.math.maxInt(SparseT));
-                self.sparse.items[pos] = new_page;
+            // Allocate new page if necessary
+            if (self.sparse.items[page_index] == null) {
+                const new_page = self.allocator.alloc(Entity.Index, page_size) catch unreachable;
+                @memset(new_page, tombstone);
+                self.sparse.items[page_index] = @ptrCast(new_page.ptr);
             }
 
-            return self.sparse.items[pos].?;
+            return self.sparse.items[page_index].?;
         }
 
         /// Increases the capacity of a sparse sets index array
@@ -116,93 +123,191 @@ pub fn SparseSet(comptime SparseT: type) type {
             return self.dense.items.len == 0;
         }
 
-        pub fn data(self: Self) []const SparseT {
+        pub fn data(self: Self) []const Entity {
             return self.dense.items;
         }
 
-        pub fn dataPtr(self: Self) *const []SparseT {
+        pub fn dataPtr(self: Self) *const []Entity {
             return &self.dense.items;
         }
 
-        pub fn contains(self: Self, sparse: SparseT) bool {
-            const curr = self.page(sparse);
-            return curr < self.sparse.items.len and
-                self.sparse.items[curr] != null and
-                self.sparse.items[curr].?[self.offset(sparse)] != std.math.maxInt(SparseT);
+        pub fn contains(self: Self, entity: Entity) bool {
+            const page_index = self.pageIndex(entity);
+            if (page_index >= self.sparse.items.len) return false;
+
+            return if (self.sparse.items[page_index]) |page|
+                page[self.pageOffset(entity)] != tombstone
+            else
+                false;
         }
 
-        /// Returns the position of an entity in a sparse set
-        pub fn index(self: Self, sparse: SparseT) SparseT {
-            std.debug.assert(self.contains(sparse));
-            return self.sparse.items[self.page(sparse)].?[self.offset(sparse)];
+        /// Returns the position of an entity in the dense array
+        /// Invokes detectable illegal behavior if the entity is
+        /// not present
+        pub fn index(self: Self, entity: Entity) Entity.Index {
+            std.debug.assert(self.contains(entity));
+            const page = self.sparse.items[self.pageIndex(entity)].?;
+            const offset = self.pageOffset(entity);
+            return page[offset];
         }
 
         /// Assigns an entity to a sparse set
-        pub fn add(self: *Self, sparse: SparseT) void {
-            std.debug.assert(!self.contains(sparse));
+        /// Invokes detectable illegal behavior if the entity is
+        /// already present
+        pub fn add(self: *Self, entity: Entity) void {
+            std.debug.assert(!self.contains(entity));
 
             // assure(page(entt))[offset(entt)] = packed.size()
-            self.assure(self.page(sparse))[self.offset(sparse)] = @intCast(self.dense.items.len);
-            _ = self.dense.append(self.allocator, sparse) catch unreachable;
+            const page = self.getOrCreatePage(self.pageIndex(entity));
+            const offset = self.pageOffset(entity);
+
+            page[offset] = @intCast(self.dense.items.len);
+            self.dense.append(self.allocator, entity) catch unreachable;
+            self.detectCorruption();
         }
 
-        /// Removes an entity from a sparse set
-        pub fn remove(self: *Self, sparse: SparseT) void {
-            std.debug.assert(self.contains(sparse));
+        /// Removes an entity from a sparse set using a swapRemove strategy.
+        /// We move the last element in the dense array to the vacated spot,
+        /// and adjust the moved element's spot in the sparse array to point
+        /// at the spot it moved to. We then mark the removed element's slot
+        /// in the sparse array as tombstoned. Finally, pop the dense array.
+        /// ```
+        /// |0 1 2 3 4 5 6 7 8 9| <- indices for reference
+        /// [1 _ 5 2 _ 4 _ 0 _ 3] <- sparse array
+        /// [7 0 3 9 5 2]         <- dense array
+        ///
+        /// step 0: Begin removal of entity 3, at index 2 in the dense array:
+        ///
+        /// |0 1 2 3 4 5 6 7 8 9|
+        ///        ↓
+        /// [1 _ 5 2 _ 4 _ 0 _ 3] <- sparse array
+        /// [7 0 3 9 5 2]         <- dense array
+        ///      ↑
+        ///
+        /// step 1: Swap the last element in the dense array (entity 2) into
+        /// the position previously occupied by entity 3 in the dense array
+        ///
+        ///  0 1 2 3 4 5 6 7 8 9
+        /// [1 _ 5 2 _ 4 _ 0 _ 3] <- sparse array
+        /// [7 0 2 9 5 _]         <- dense array
+        ///      ↑-----↓
+        ///
+        /// step 2: Change the entry of entity 2 in the sparse array to
+        /// point at entity 2's new position
+        ///
+        ///  0 1 2 3 4 5 6 7 8 9
+        ///      ↓
+        /// [1 _ 2 2 _ 4 _ 0 _ 3] <- sparse array
+        /// [7 0 2 9 5 _]         <- dense array
+        ///
+        /// step 3: Mark the entry of entity 3 in the sparse array as
+        /// a tombstone
+        ///
+        ///  0 1 2 3 4 5 6 7 8 9
+        ///        ↓
+        /// [1 _ 2 _ _ 4 _ 0 _ 3] <- sparse array
+        /// [7 0 2 9 5 _]         <- dense array
+        ///
+        /// step 4: Shrink the dense array by 1 element
+        ///
+        ///  0 1 2 3 4 5 6 7 8 9
+        /// [1 _ 2 _ _ 4 _ 0 _ 3] <- sparse array
+        /// [7 0 2 9 5]         <- dense array
+        /// ```
+        pub fn remove(self: *Self, entity: Entity) void {
+            std.debug.assert(self.contains(entity));
 
-            const curr = self.page(sparse);
-            const pos = self.offset(sparse);
+            const page_index = self.pageIndex(entity);
+            const offset = self.pageOffset(entity);
+
+            // position of the removed entity in the dense array
+            const removed_entity_dense_pos = self.sparse.items[page_index].?[offset];
+            // last entity in the dense array
             const last_dense = self.dense.items[self.dense.items.len - 1];
 
-            self.dense.items[self.sparse.items[curr].?[pos]] = last_dense;
-            self.sparse.items[self.page(last_dense)].?[self.offset(last_dense)] = self.sparse.items[curr].?[pos];
-            self.sparse.items[curr].?[pos] = std.math.maxInt(SparseT);
+            // move the last entity in the dense array to the position of the removed entity
+            self.dense.items[removed_entity_dense_pos] = last_dense;
+
+            // point the sparse entry of the moved entity to its new position
+            self.sparse.items[self.pageIndex(last_dense)].?[self.pageOffset(last_dense)] = removed_entity_dense_pos;
+            // tombstone removed entity in sparse array
+            self.sparse.items[page_index].?[offset] = tombstone;
 
             _ = self.dense.pop();
+            self.detectCorruption();
         }
 
         /// Swaps two entities in the internal packed and sparse arrays
-        pub fn swap(self: *Self, lhs: SparseT, rhs: SparseT) void {
-            const from = &self.sparse.items[self.page(lhs)].?[self.offset(lhs)];
-            const to = &self.sparse.items[self.page(rhs)].?[self.offset(rhs)];
+        pub fn swap(self: *Self, lhs: Entity, rhs: Entity) void {
+            const from = &self.sparse.items[self.pageIndex(lhs)].?[self.pageOffset(lhs)];
+            const to = &self.sparse.items[self.pageIndex(rhs)].?[self.pageOffset(rhs)];
 
-            std.mem.swap(SparseT, &self.dense.items[from.*], &self.dense.items[to.*]);
-            std.mem.swap(SparseT, from, to);
+            std.mem.swap(Entity, &self.dense.items[from.*], &self.dense.items[to.*]);
+            std.mem.swap(Entity.Index, from, to);
+            self.detectCorruption();
         }
 
         /// Sort elements according to the given comparison function
-        pub fn sort(self: *Self, context: anytype, comptime lessThan: *const fn (@TypeOf(context), SparseT, SparseT) bool) void {
-            std_sort_insertionSort_clone(SparseT, self.dense.items, context, lessThan);
+        pub fn sort(self: *Self, context: anytype, comptime lessThan: *const fn (@TypeOf(context), Entity, Entity) bool) void {
+            std_sort_insertionSort_clone(Entity, self.dense.items, context, lessThan);
 
-            for (self.dense.items, 0..) |_, i| {
-                const item: SparseT = @intCast(i);
-                self.sparse.items[self.page(self.dense.items[self.page(item)])].?[self.offset(self.dense.items[self.page(item)])] = @as(SparseT, @intCast(i));
+            for (self.dense.items, 0..) |entity, i| {
+                self.sparse.items[
+                    self.pageIndex(entity)
+                ].?[
+                    self.pageOffset(entity)
+                ] = @intCast(i);
             }
+            self.detectCorruption();
         }
 
         /// Sort elements according to the given comparison function. Use this when a data array needs to stay in sync with the SparseSet
         /// by passing in a "swap_context" that contains a "swap" method with a sig of fn(ctx,SparseT,SparseT)void
-        pub fn arrange(self: *Self, length: usize, context: anytype, comptime lessThan: *const fn (@TypeOf(context), SparseT, SparseT) bool, swap_context: anytype) void {
-            std_sort_insertionSort_clone(SparseT, self.dense.items[0..length], context, lessThan);
+        /// We first sort the dense array, then use the sparse array as a reference to permute the data array.
+        /// https://skypjack.github.io/2019-09-25-ecs-baf-part-5/
+        pub fn arrange(
+            self: *Self,
+            /// swaps elements between 0..length (exclusive)
+            length: usize,
+            context: anytype,
+            comptime lessThan: *const fn (@TypeOf(context), Entity, Entity) bool,
+            swap_context: anytype,
+        ) void {
+            // first, sort dense array
+            std_sort_insertionSort_clone(Entity, self.dense.items[0..length], context, lessThan);
+            // we have to figure out where the element in the dense array went
+            // iterating over sorted elements on dense array...
 
-            for (self.dense.items[0..length], 0..) |_, pos| {
-                var curr: SparseT = @intCast(pos);
-                var next = self.index(self.dense.items[curr]);
+            for (0..length) |i| {
+                var pos_current: Entity.Index = @intCast(i);
+                var curr_entity = self.dense.items[pos_current];
+                // where the entity at dense[curr] used to be in dense before sorting
+                var pos_before_sorting: Entity.Index = self.index(curr_entity);
 
-                while (curr != next) {
-                    swap_context.swap(self.dense.items[curr], self.dense.items[next]);
-                    self.sparse.items[self.page(self.dense.items[curr])].?[self.offset(self.dense.items[curr])] = curr;
+                // if we have already finished this cycle, this will immediately be true
+                // otherwise, we permute the entire cycle, stopping when we wrap aroun to the start
+                while (pos_current != pos_before_sorting) {
+                    // update sparse array
+                    // this also marks this index as complete so we don't repeat cycles
+                    self.sparse.items[
+                        self.pageIndex(curr_entity)
+                    ].?[
+                        self.pageOffset(curr_entity)
+                    ] = pos_current;
+                    swap_context.swap(self.dense.items[pos_current], self.dense.items[pos_before_sorting]);
 
-                    curr = next;
-                    next = self.index(self.dense.items[curr]);
+                    pos_current = pos_before_sorting;
+                    curr_entity = self.dense.items[pos_current];
+                    pos_before_sorting = self.index(curr_entity);
                 }
             }
+            self.detectCorruption();
         }
 
         /// Sort entities according to their order in another sparse set. Other is the master in this case.
         pub fn respect(self: *Self, other: *Self) void {
-            var pos: SparseT = 0;
-            var i: SparseT = 0;
+            var pos: Entity.Index = 0;
+            var i: Entity.Index = 0;
             while (i < other.dense.items.len) : (i += 1) {
                 if (self.contains(other.dense.items[i])) {
                     if (other.dense.items[i] != self.dense.items[pos]) {
@@ -211,30 +316,60 @@ pub fn SparseSet(comptime SparseT: type) type {
                     pos += 1;
                 }
             }
+            self.detectCorruption();
+            other.detectCorruption();
         }
 
         pub fn clear(self: *Self) void {
-            for (self.sparse.items, 0..) |array, i| {
-                if (array) |arr| {
-                    self.allocator.free(arr);
+            for (self.sparse.items, 0..) |maybe_page, i| {
+                if (maybe_page) |page| {
+                    self.allocator.free(page);
                     self.sparse.items[i] = null;
                 }
             }
 
             self.sparse.items.len = 0;
             self.dense.items.len = 0;
+            self.detectCorruption();
         }
 
-        pub fn reverseIterator(self: *Self) ReverseSliceIterator(SparseT) {
-            return ReverseSliceIterator(SparseT).init(self.dense.items);
+        pub fn reverseIterator(self: *Self) ReverseSliceIterator(Entity) {
+            return ReverseSliceIterator(Entity).init(self.dense.items);
+        }
+
+        pub fn detectCorruption(self: *Self) void {
+            if (!@import("builtin").is_test) return;
+
+            var entities: std.AutoHashMapUnmanaged(Entity, void) = .empty;
+            defer entities.deinit(self.allocator);
+
+            // make sure that all elements only exist once
+            for (self.dense.items, 0..) |entity, i| {
+                if (entities.fetchPut(self.allocator, entity, void{}) catch unreachable) |_| std.debug.panic("set corrupted: duplicate entry in dense list", .{});
+                if (!self.contains(entity)) std.debug.panic("set corrupted: orphaned entry in dense list", .{});
+                if (self.index(entity) != i) std.debug.panic("set corrupted: entry in sparse list points to wrong entity in dense list", .{});
+            }
+
+            var indices: std.AutoHashMapUnmanaged(Entity.Index, void) = .empty;
+            defer indices.deinit(self.allocator);
+
+            // make sure all elements are only pointed to once
+            for (self.sparse.items) |maybe_page| {
+                if (maybe_page) |page| {
+                    for (page) |dense_index| {
+                        if (dense_index == tombstone) continue;
+                        if (indices.fetchPut(self.allocator, dense_index, void{}) catch unreachable) |_| std.debug.panic("set corrupted: two locations in sparse list point to same entry", .{});
+                    }
+                }
+            }
         }
     };
 }
 
-fn printSet(set: *SparseSet(u32, u8)) void {
+fn printSet(set: anytype) void {
     std.debug.print("\nsparse -----\n", .{});
-    for (set.sparse.items) |sparse| {
-        std.debug.print("{}\t", .{sparse});
+    for (set.sparse) |page| {
+        std.debug.print("{}\t", .{page});
     }
 
     std.debug.print("\ndense -----\n", .{});
@@ -245,16 +380,20 @@ fn printSet(set: *SparseSet(u32, u8)) void {
 }
 
 test "add/remove/clear" {
-    var set = SparseSet(u32).create(std.testing.allocator);
+    const Entity = @import("entity.zig").DefaultEntity;
+    var set = SparseSet(Entity).create(std.testing.allocator);
     defer set.destroy();
 
-    set.add(4);
-    set.add(3);
-    try std.testing.expectEqual(set.len(), 2);
-    try std.testing.expectEqual(set.index(4), 0);
-    try std.testing.expectEqual(set.index(3), 1);
+    const e0: Entity = .{ .index = 4, .version = 0 };
+    const e1: Entity = .{ .index = 3, .version = 0 };
 
-    set.remove(4);
+    set.add(e0);
+    set.add(e1);
+    try std.testing.expectEqual(set.len(), 2);
+    try std.testing.expectEqual(set.index(e0), 0);
+    try std.testing.expectEqual(set.index(e1), 1);
+
+    set.remove(e0);
     try std.testing.expectEqual(set.len(), 1);
 
     set.clear();
@@ -262,82 +401,100 @@ test "add/remove/clear" {
 }
 
 test "grow" {
-    var set = SparseSet(u32).create(std.testing.allocator);
+    const Entity = @import("entity.zig").DefaultEntity;
+    var set = SparseSet(Entity).create(std.testing.allocator);
     defer set.destroy();
 
     var i: usize = std.math.maxInt(u8);
     while (i > 0) : (i -= 1) {
-        set.add(@intCast(i));
+        set.add(.{ .index = @intCast(i), .version = 0 });
     }
 
     try std.testing.expectEqual(set.len(), std.math.maxInt(u8));
 }
 
 test "swap" {
-    var set = SparseSet(u32).create(std.testing.allocator);
+    const Entity = @import("entity.zig").DefaultEntity;
+    var set = SparseSet(Entity).create(std.testing.allocator);
     defer set.destroy();
 
-    set.add(4);
-    set.add(3);
-    try std.testing.expectEqual(set.index(4), 0);
-    try std.testing.expectEqual(set.index(3), 1);
+    const e0: Entity = .{ .index = 4, .version = 0 };
+    const e1: Entity = .{ .index = 3, .version = 0 };
 
-    set.swap(4, 3);
-    try std.testing.expectEqual(set.index(3), 0);
-    try std.testing.expectEqual(set.index(4), 1);
+    set.add(e0);
+    set.add(e1);
+    try std.testing.expectEqual(set.index(e0), 0);
+    try std.testing.expectEqual(set.index(e1), 1);
+
+    set.swap(e0, e1);
+    try std.testing.expectEqual(set.index(e1), 0);
+    try std.testing.expectEqual(set.index(e0), 1);
 }
 
 test "data() synced" {
-    var set = SparseSet(u32).create(std.testing.allocator);
+    const Entity = @import("entity.zig").DefaultEntity;
+    var set = SparseSet(Entity).create(std.testing.allocator);
     defer set.destroy();
 
-    set.add(0);
-    set.add(1);
-    set.add(2);
-    set.add(3);
+    const e0: Entity = .{ .index = 0, .version = 0 };
+    const e1: Entity = .{ .index = 1, .version = 0 };
+    const e2: Entity = .{ .index = 2, .version = 0 };
+    const e3: Entity = .{ .index = 3, .version = 0 };
+
+    set.add(e0);
+    set.add(e1);
+    set.add(e2);
+    set.add(e3);
 
     const data = set.data();
-    try std.testing.expectEqual(data[1], 1);
+    try std.testing.expectEqual(data[1], e1);
     try std.testing.expectEqual(set.len(), data.len);
 
-    set.remove(0);
-    set.remove(1);
+    set.remove(e0);
+    set.remove(e1);
     try std.testing.expectEqual(set.len(), set.data().len);
 }
 
 test "iterate" {
-    var set = SparseSet(u32).create(std.testing.allocator);
+    const Entity = @import("entity.zig").DefaultEntity;
+    var set = SparseSet(Entity).create(std.testing.allocator);
     defer set.destroy();
 
-    set.add(0);
-    set.add(1);
-    set.add(2);
-    set.add(3);
+    const e0: Entity = .{ .index = 0, .version = 0 };
+    const e1: Entity = .{ .index = 1, .version = 0 };
+    const e2: Entity = .{ .index = 2, .version = 0 };
+    const e3: Entity = .{ .index = 3, .version = 0 };
+
+    set.add(e0);
+    set.add(e1);
+    set.add(e2);
+    set.add(e3);
 
     var i: u32 = @as(u32, @intCast(set.len())) - 1;
     var iter = set.reverseIterator();
     while (iter.next()) |entity| {
-        try std.testing.expectEqual(i, entity);
+        try std.testing.expectEqual(@as(Entity, .{ .index = @intCast(i), .version = 0 }), entity);
         if (i > 0) i -= 1;
     }
 }
 
 test "respect 1" {
-    var set1 = SparseSet(u32).create(std.testing.allocator);
+    const Entity = @import("entity.zig").DefaultEntity;
+    var set1 = SparseSet(Entity).create(std.testing.allocator);
     defer set1.destroy();
 
-    var set2 = SparseSet(u32).create(std.testing.allocator);
+    var set2 = SparseSet(Entity).create(std.testing.allocator);
     defer set2.destroy();
 
-    set1.add(3);
-    set1.add(4);
-    set1.add(5);
-    set1.add(6);
-    set1.add(7);
+    set1.add(.{ .index = 3, .version = 0 });
+    set1.add(.{ .index = 4, .version = 0 });
+    set1.add(.{ .index = 5, .version = 0 });
+    set1.add(.{ .index = 6, .version = 0 });
+    set1.add(.{ .index = 7, .version = 0 });
 
-    set2.add(8);
-    set2.add(6);
-    set2.add(4);
+    set2.add(.{ .index = 8, .version = 0 });
+    set2.add(.{ .index = 6, .version = 0 });
+    set2.add(.{ .index = 4, .version = 0 });
 
     set1.respect(set2);
 
@@ -345,23 +502,24 @@ test "respect 1" {
     try std.testing.expectEqual(set1.dense.items[1], set2.dense.items[2]);
 }
 
-const desc_u32 = std.sort.desc(u32);
-
 test "respect 2" {
-    var set = SparseSet(u32).create(std.testing.allocator);
+    const Entity = @import("entity.zig").DefaultEntity;
+    var set = SparseSet(Entity).create(std.testing.allocator);
     defer set.destroy();
 
-    set.add(5);
-    set.add(2);
-    set.add(4);
-    set.add(1);
-    set.add(3);
+    set.add(.{ .index = 5, .version = 0 });
+    set.add(.{ .index = 2, .version = 0 });
+    set.add(.{ .index = 4, .version = 0 });
+    set.add(.{ .index = 1, .version = 0 });
+    set.add(.{ .index = 3, .version = 0 });
 
-    set.sort({}, desc_u32);
-
-    for (set.dense.items, 0..) |item, i| {
-        if (i < set.dense.items.len - 1) {
-            std.debug.assert(item > set.dense.items[i + 1]);
+    set.sort({}, struct {
+        pub fn desc(_: void, a: Entity, b: Entity) bool {
+            return a.index > b.index;
         }
+    }.desc);
+
+    for (set.dense.items[0 .. set.dense.items.len - 1], 0..) |entity, i| {
+        std.debug.assert(entity.index > set.dense.items[i + 1].index);
     }
 }

--- a/src/ecs/sparse_set.zig
+++ b/src/ecs/sparse_set.zig
@@ -275,30 +275,20 @@ pub fn SparseSet(comptime Entity: type) type {
         ) void {
             // first, sort dense array
             std_sort_insertionSort_clone(Entity, self.dense.items[0..length], context, lessThan);
-            // we have to figure out where the element in the dense array went
-            // iterating over sorted elements on dense array...
-
             for (0..length) |i| {
-                var pos_current: Entity.Index = @intCast(i);
-                var curr_entity = self.dense.items[pos_current];
-                // where the entity at dense[curr] used to be in dense before sorting
-                var pos_before_sorting: Entity.Index = self.index(curr_entity);
+                var curr: Entity.Index = @intCast(i);
+                var next = self.index(self.dense.items[curr]);
 
-                // if we have already finished this cycle, this will immediately be true
-                // otherwise, we permute the entire cycle, stopping when we wrap aroun to the start
-                while (pos_current != pos_before_sorting) {
-                    // update sparse array
-                    // this also marks this index as complete so we don't repeat cycles
+                while (curr != next) {
+                    swap_context.swap(self.dense.items[curr], self.dense.items[next]);
                     self.sparse.items[
-                        self.pageIndex(curr_entity)
+                        self.pageIndex(self.dense.items[curr])
                     ].?[
-                        self.pageOffset(curr_entity)
-                    ] = pos_current;
-                    swap_context.swap(self.dense.items[pos_current], self.dense.items[pos_before_sorting]);
+                        self.pageOffset(self.dense.items[curr])
+                    ] = curr;
 
-                    pos_current = pos_before_sorting;
-                    curr_entity = self.dense.items[pos_current];
-                    pos_before_sorting = self.index(curr_entity);
+                    curr = next;
+                    next = self.index(self.dense.items[curr]);
                 }
             }
             self.detectCorruption();

--- a/src/ecs/views.zig
+++ b/src/ecs/views.zig
@@ -279,14 +279,14 @@ test "single basic view" {
     var store = Storage(f32).init(std.testing.allocator);
     defer store.deinit();
 
-    store.add(3, 30);
-    store.add(5, 50);
-    store.add(7, 70);
+    store.add(.{ .index = 3, .version = 0 }, 30);
+    store.add(.{ .index = 5, .version = 0 }, 50);
+    store.add(.{ .index = 7, .version = 0 }, 70);
 
     var view = BasicView(f32).init(&store);
     try std.testing.expectEqual(view.len(), 3);
 
-    store.remove(7);
+    store.remove(.{ .index = 7, .version = 0 });
     try std.testing.expectEqual(view.len(), 2);
 
     var i: usize = 0;
@@ -301,11 +301,11 @@ test "single basic view" {
     var entIter = view.entityIterator();
     while (entIter.next()) |ent| {
         if (i == 0) {
-            try std.testing.expectEqual(ent, 5);
+            try std.testing.expectEqual(@as(Entity, .{ .index = 5, .version = 0 }), ent);
             try std.testing.expectEqual(view.getConst(ent), 50);
         }
         if (i == 1) {
-            try std.testing.expectEqual(ent, 3);
+            try std.testing.expectEqual(ent, @as(Entity, .{ .index = 3, .version = 0 }));
             try std.testing.expectEqual(view.getConst(ent), 30);
         }
         i += 1;
@@ -316,21 +316,21 @@ test "single basic view data" {
     var store = Storage(f32).init(std.testing.allocator);
     defer store.deinit();
 
-    store.add(3, 30);
-    store.add(5, 50);
-    store.add(7, 70);
+    store.add(.{ .index = 3, .version = 0 }, 30);
+    store.add(.{ .index = 5, .version = 0 }, 50);
+    store.add(.{ .index = 7, .version = 0 }, 70);
 
     var view = BasicView(f32).init(&store);
 
-    try std.testing.expectEqual(view.get(3).*, 30);
+    try std.testing.expectEqual(view.get(.{ .index = 3, .version = 0 }).*, 30);
 
     for (view.data(), 0..) |entity, i| {
         if (i == 0)
-            try std.testing.expectEqual(entity, 3);
+            try std.testing.expectEqual(entity, @as(Entity, .{ .index = 3, .version = 0 }));
         if (i == 1)
-            try std.testing.expectEqual(entity, 5);
+            try std.testing.expectEqual(entity, @as(Entity, .{ .index = 5, .version = 0 }));
         if (i == 2)
-            try std.testing.expectEqual(entity, 7);
+            try std.testing.expectEqual(entity, @as(Entity, .{ .index = 7, .version = 0 }));
     }
 
     for (view.raw(), 0..) |data, i| {

--- a/tests/groups_test.zig
+++ b/tests/groups_test.zig
@@ -234,7 +234,7 @@ test "nested OwningGroups entity order" {
     _ = reg.assure(Transform);
     // printStore(sprite_store, "Sprite");
 
-    reg.add(1, Transform{ .x = 1 });
+    reg.add(.{ .index = 1, .version = 0 }, Transform{ .x = 1 });
 
     // printStore(sprite_store, "Sprite");
     // printStore(transform_store, "Transform");

--- a/tests/handles_test.zig
+++ b/tests/handles_test.zig
@@ -1,0 +1,69 @@
+test "handles stress test" {
+    const Entity = ecs.EntityClass(.{ .index_bits = 8, .version_bits = 4, .total_bits = 12 });
+    const Handles = ecs.Handles(Entity);
+
+    var handles: Handles = .init(std.testing.allocator);
+
+    var entity: Entity = undefined;
+    // create 15 entities
+    for (0..Handles.max_active_entities) |_| {
+        entity = try handles.create();
+        try handles.remove(entity);
+
+        entity = try handles.create();
+    }
+    // last one cannot be created because the index would coincide with our tombstone/invalid slot
+    try std.testing.expectError(error.OutOfActiveHandles, handles.create());
+    handles.deinit();
+
+    handles = .init(std.testing.allocator);
+    var entities: std.ArrayListUnmanaged(Entity) = try .initCapacity(std.testing.allocator, Handles.max_active_entities);
+    defer entities.deinit(std.testing.allocator);
+    defer handles.deinit();
+
+    var xoro: std.Random.Xoshiro256 = .init(78425829754);
+    const rand = xoro.random();
+    var tested_scenarios: [4]bool = @splat(false);
+    const iters = 10_000;
+    for (0..iters) |i| {
+        // vary this to cover all cases
+        const remove_probability: f32 = if (i < iters / 2)
+            2 * @as(f32, @floatFromInt(i)) / @as(f32, @floatFromInt(iters))
+        else
+            -2 * @as(f32, @floatFromInt(i)) / @as(f32, @floatFromInt(iters)) + 2;
+
+        // remove entity from list
+        if (rand.float(f32) < remove_probability) {
+            if (entities.items.len > 0) {
+                // choose random entity to remove
+                const to_remove: Entity = entities.swapRemove(rand.uintLessThan(usize, entities.items.len));
+                try handles.remove(to_remove);
+                tested_scenarios[0] = true;
+            } else {
+                // remove random id and expect failure
+                try std.testing.expectError(error.RemovedInvalidHandle, handles.remove(.{ .index = rand.uintLessThan(u4, 15), .version = rand.int(u4) }));
+                tested_scenarios[1] = true;
+            }
+        }
+        // create entity
+        else {
+            if (entities.items.len < Handles.max_active_entities) {
+                // create new entity
+                entities.appendAssumeCapacity(try handles.create());
+                tested_scenarios[2] = true;
+            } else {
+                // out of entities, create new entity and expect failure
+                try std.testing.expectError(error.OutOfActiveHandles, handles.create());
+                tested_scenarios[3] = true;
+            }
+        }
+    }
+    try std.testing.expectEqualSlices(
+        bool,
+        &@as([4]bool, @splat(true)),
+        &tested_scenarios,
+    );
+}
+
+const ecs = @import("ecs");
+const std = @import("std");

--- a/tests/registry_test.zig
+++ b/tests/registry_test.zig
@@ -8,7 +8,7 @@ const Empty = struct {};
 const BigOne = struct { pos: Position, vel: Velocity, accel: Velocity };
 
 test "entity traits" {
-    _ = ecs.EntityTraitsType(.large).init();
+    _ = ecs.EntityClass(.large){ .version = 0, .index = 0 };
 }
 
 test "Registry" {

--- a/tests/registry_test.zig
+++ b/tests/registry_test.zig
@@ -100,13 +100,16 @@ test "destroy" {
         reg.add(e, Position{ .x = @as(f32, @floatFromInt(i)), .y = @as(f32, @floatFromInt(i)) });
     }
 
-    reg.destroy(3);
-    reg.destroy(4);
+    reg.destroy(.{ .index = 3, .version = 0 });
+    reg.destroy(.{ .index = 4, .version = 0 });
 
     i = 0;
     while (i < 6) : (i += 1) {
         if (i != 3 and i != 4)
-            try std.testing.expectEqual(Position{ .x = @as(f32, @floatFromInt(i)), .y = @as(f32, @floatFromInt(i)) }, reg.getConst(Position, i));
+            try std.testing.expectEqual(
+                Position{ .x = @as(f32, @floatFromInt(i)), .y = @as(f32, @floatFromInt(i)) },
+                reg.getConst(Position, .{ .index = i, .version = 0 }),
+            );
     }
 }
 

--- a/tests/registry_test.zig
+++ b/tests/registry_test.zig
@@ -8,7 +8,10 @@ const Empty = struct {};
 const BigOne = struct { pos: Position, vel: Velocity, accel: Velocity };
 
 test "entity traits" {
-    _ = ecs.EntityClass(.large){ .version = 0, .index = 0 };
+    _ = ecs.EntityClass(.small){ .index = 299, .version = 15 };
+    _ = ecs.EntityClass(.medium){ .index = 18953, .version = 543 };
+    _ = ecs.EntityClass(.large){ .index = 15794, .version = 548273 };
+    _ = ecs.EntityClass(.{ .index_bits = 41, .version_bits = 91, .total_bits = 41 + 91 }){ .index = 89612, .version = 254739 };
 }
 
 test "Registry" {

--- a/tests/tests.zig
+++ b/tests/tests.zig
@@ -2,4 +2,5 @@ test "ecs test suite" {
     _ = @import("dispatcher_test.zig");
     _ = @import("registry_test.zig");
     _ = @import("groups_test.zig");
+    _ = @import("handles_test.zig");
 }


### PR DESCRIPTION
- Improves type safety
- Simplifies some internal code (no need for helper functions to unpack index/version)
Also:
- Better document SparseSet operations
- Instead of being unable to deallocate the last entity, don't hand it out instead