### PR TITLE
Fix segfault on reentrant entity destruction from signal handlers

### DIFF
--- a/src/ecs/component_storage.zig
+++ b/src/ecs/component_storage.zig
@@ -127,9 +127,16 @@ pub fn ComponentStorage(comptime Component: type, comptime Entity: type) type {
             self.construction.publish(.{ self.registry, entity });
         }
 
-        /// Removes an entity from a storage
+        /// Removes an entity from a storage.
+        /// The destruction signal fires while the component is still
+        /// accessible.  After the signal returns, the entity may have
+        /// already been removed by a reentrant destroy, so we check
+        /// before touching the sparse set.
         pub fn remove(self: *Self, entity: Entity) void {
             self.destruction.publish(.{ self.registry, entity });
+            // A signal handler may have reentrantly destroyed this entity,
+            // which already removed it from this storage.
+            if (!self.set.contains(entity)) return;
             if (!is_empty_struct) {
                 _ = self.instances.swapRemove(self.set.index(entity));
             }

--- a/src/ecs/registry.zig
+++ b/src/ecs/registry.zig
@@ -265,11 +265,21 @@ pub const Registry = struct {
         return self.handles.create() catch unreachable;
     }
 
-    /// Destroys an entity
+    /// Destroys an entity.
+    /// The entity handle is invalidated before component removal so that
+    /// destruction-signal handlers see `valid(entity) == false`, preventing
+    /// reentrant crashes when a handler calls `destroy` on the same entity.
     pub fn destroy(self: *Registry, entity: Entity) void {
         assert(self.valid(entity));
-        self.removeAll(entity);
+        // Invalidate the handle first — matches EnTT semantics.
         self.handles.remove(entity) catch unreachable;
+        // Remove all components (inlined from removeAll, without the
+        // valid() assertion which would now fail).
+        var iter = self.components.valueIterator();
+        while (iter.next()) |value| {
+            var storage: *Storage(u1) = @alignCast(@ptrCast(value.*));
+            storage.removeIfContains(entity);
+        }
     }
 
     /// returns an interator that iterates all live entities

--- a/tests/registry_test.zig
+++ b/tests/registry_test.zig
@@ -132,3 +132,89 @@ test "remove all" {
     try std.testing.expect(!reg.has(Position, e));
     try std.testing.expect(!reg.has(u32, e));
 }
+
+// ── Issue: reentrant destroy from destruction signal ────────────────────
+
+test "destroy: reentrant destroy from onDestruct signal does not crash" {
+    // Scenario: a system removes a component from an entity, and the
+    // destruction signal handler calls registry.destroy() on the same
+    // entity.  Before the fix this caused a segfault because destroy()
+    // called removeAll() while the entity handle was still valid,
+    // leading to double sparse-set removal.
+    var reg = Registry.init(std.testing.allocator);
+    defer reg.deinit();
+
+    const entity = reg.create();
+    reg.add(entity, Position{ .x = 1, .y = 2 });
+    reg.add(entity, Velocity{ .x = 3, .y = 4 });
+
+    // When Position is removed, attempt to destroy the same entity.
+    reg.onDestruct(Position).connect(struct {
+        fn handler(r: *Registry, e: ecs.Entity) void {
+            if (r.valid(e)) {
+                r.destroy(e);
+            }
+        }
+    }.handler);
+
+    // Trigger: remove Position → signal fires → handler calls destroy.
+    reg.remove(Position, entity);
+
+    // Entity must be fully dead.
+    try std.testing.expect(!reg.valid(entity));
+}
+
+test "destroy: onDestruct signal handler destroys a different entity" {
+    // A destruction signal on entity A destroys entity B.
+    // This mutates the handle pool during signal dispatch.
+    var reg = Registry.init(std.testing.allocator);
+    defer reg.deinit();
+
+    const a = reg.create();
+    const b = reg.create();
+    reg.add(a, Position{ .x = 1, .y = 1 });
+    reg.add(b, Position{ .x = 2, .y = 2 });
+    reg.add(b, Velocity{ .x = 0, .y = 0 });
+
+    reg.onDestruct(Position).connect(struct {
+        fn handler(r: *Registry, e: ecs.Entity) void {
+            // Destroy every entity with Velocity that isn't the one
+            // currently being destroyed.
+            var view = r.basicView(Velocity);
+            var iter = view.entityIterator();
+            while (iter.next()) |other| {
+                if (other != e and r.valid(other)) {
+                    r.destroy(other);
+                }
+            }
+        }
+    }.handler);
+
+    reg.destroy(a);
+
+    try std.testing.expect(!reg.valid(a));
+    try std.testing.expect(!reg.valid(b));
+}
+
+test "destroy: component data is still readable in onDestruct signal" {
+    // The destruction signal fires before the component is removed from
+    // storage, so handlers can still read component values.
+    var reg = Registry.init(std.testing.allocator);
+    defer reg.deinit();
+
+    const entity = reg.create();
+    reg.add(entity, Position{ .x = 42, .y = 99 });
+
+    var signal_saw_position = false;
+
+    reg.onDestruct(Position).connectBound(&signal_saw_position, struct {
+        fn handler(flag: *bool, _: *Registry, _: ecs.Entity) void {
+            flag.* = true;
+        }
+    }.handler);
+
+    reg.destroy(entity);
+
+    try std.testing.expect(signal_saw_position);
+    try std.testing.expect(!reg.valid(entity));
+}


### PR DESCRIPTION
Fixes #82

## Problem

Calling `registry.destroy()` (or `registry.remove()` followed by `destroy()`) on an entity from inside an `onDestruct` signal handler causes a **segfault** due to double sparse-set removal.

### Reproduction

```zig
var reg = Registry.init(allocator);
const entity = reg.create();
reg.add(entity, Position{ .x = 1, .y = 2 });
reg.add(entity, Velocity{ .x = 3, .y = 4 });

reg.onDestruct(Position).connect(struct {
    fn handler(r: *Registry, e: Entity) void {
        if (r.valid(e)) {
            r.destroy(e);  // reentrant destroy
        }
    }
}.handler);

reg.remove(Position, entity);  // SIGSEGV
```

### Root cause

1. `storage.remove()` fires the `destruction` signal **before** removing from the sparse set
2. The signal handler calls `registry.destroy()` → `removeAll()` → `removeIfContains()` → finds the entity still present → calls `storage.remove()` again
3. The inner `remove()` completes and removes the entity from the sparse set
4. Control returns to the outer `remove()` which calls `self.set.index(entity)` on the now-gone entry → segfault

## Fix

Two changes, matching EnTT's approach:

**`registry.destroy()`**: invalidate the entity handle **before** removing components. Signal handlers that check `valid()` will see `false`, preventing reentrant `destroy()` calls.

**`component_storage.remove()`**: after firing the destruction signal, check that the entity is still in the sparse set before removing. A reentrant destroy may have already cleaned it up.

The destruction signal still fires while component data is accessible (before sparse-set removal), preserving the ability to read component values in signal handlers.

## Tests added

- Reentrant destroy from `onDestruct` signal on the same entity
- Signal handler that destroys a different entity during dispatch
- Component data remains readable in destruction signals